### PR TITLE
feat: Add BeInRange assertion for numeric range validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ func TestBasicAssertions(t *testing.T) {
 	should.BeLessThan(t, 3, 7)
 	should.BeLessOrEqualTo(t, 5, 10)
 
+	// Range validation
+	should.BeInRange(t, user.Age, 18, 65)
+	should.BeInRange(t, testScore, 0, 100)
+	should.BeInRange(t, response.StatusCode, 200, 299)
+
 	// Numeric comparisons with custom messages
 	should.BeGreaterThan(t, user.Age, 18, should.WithMessage("User must be adult"))
 	should.BeGreaterOrEqualTo(t, score, 0, should.WithMessage("Score cannot be negative"))
@@ -171,6 +176,34 @@ should.BeLessOrEqualTo(t, 15, 10)
 //         Threshold : 10
 //         Difference: +5 (value is 5 greater)
 //         Hint      : Value should be smaller than or equal to threshold
+
+// Range validation (fails when value is below or above the range)
+should.BeInRange(t, 16, 18, 65)
+// Output:
+// Expected value to be in range [18, 65], but it was below:
+//         Value    : 16
+//         Range    : [18, 65]
+//         Distance : 2 below minimum (16 < 18)
+//         Hint     : Value should be >= 18
+
+// Range validation (fails when value is above the range)
+should.BeInRange(t, 105, 0, 100)
+// Output:
+// Expected value to be in range [0, 100], but it was above:
+//         Value    : 105
+//         Range    : [0, 100]
+//         Distance : 5 above maximum (105 > 100)
+//         Hint     : Value should be <= 100
+
+// Range validation with custom message
+should.BeInRange(t, 150, 0, 100, should.WithMessage("Battery level must be valid percentage"))
+// Output:
+// Battery level must be valid percentage
+// Expected value to be in range [0, 100], but it was above:
+//         Value    : 150
+//         Range    : [0, 100]
+//         Distance : 50 above maximum (150 > 100)
+//         Hint     : Value should be <= 100
 ```
 
 ### Struct and Object Comparisons
@@ -481,6 +514,7 @@ should.NotContainValue(t, userRoles, 3)
 - `BeLessThan(t, actual, threshold)` - Numeric less-than comparison
 - `BeGreaterOrEqualTo(t, actual, threshold)` - Numeric greater-than-or-equal comparison
 - `BeLessOrEqualTo(t, actual, threshold)` - Numeric less-than-or-equal comparison
+- `BeInRange(t, actual, minValue, maxValue)` - Check if value is within inclusive range [minValue, maxValue]
 
 ### String Operations
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -441,14 +441,14 @@ func BeLessOrEqualTo[T Ordered](t testing.TB, actual T, expected T, opts ...Opti
 //	should.BeInRange(t, 200, 200, 299, should.WithMessage("HTTP status should be 2xx"))
 //
 // Only works with numeric types. All values must be of the same type.
-func BeInRange[T Ordered](t testing.TB, actual T, min T, max T, opts ...Option) {
+func BeInRange[T Ordered](t testing.TB, actual T, minValue T, maxValue T, opts ...Option) {
 	t.Helper()
-	if actual >= min && actual <= max {
+	if actual >= minValue && actual <= maxValue {
 		return
 	}
 
 	cfg := processOptions(opts...)
-	errorMsg := formatRangeError(actual, min, max)
+	errorMsg := formatRangeError(actual, minValue, maxValue)
 
 	if cfg.Message != "" {
 		fail(t, "%s\n%s", cfg.Message, errorMsg)

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -426,6 +426,52 @@ func BeLessOrEqualTo[T Ordered](t testing.TB, actual T, expected T, opts ...Opti
 	}
 }
 
+// BeInRange reports a test failure if the value is not within the specified range (inclusive).
+//
+// This assertion works with all numeric types and provides detailed
+// error messages when the assertion fails, indicating whether the value is
+// above or below the range and by how much.
+//
+// Example:
+//
+//	should.BeInRange(t, 25, 18, 65)
+//
+//	should.BeInRange(t, 99.5, 0.0, 100.0)
+//
+//	should.BeInRange(t, 200, 200, 299, should.WithMessage("HTTP status should be 2xx"))
+//
+// Only works with numeric types. All values must be of the same type.
+func BeInRange[T Ordered](t testing.TB, actual T, min T, max T, opts ...Option) {
+	t.Helper()
+	if actual >= min && actual <= max {
+		return
+	}
+
+	cfg := processOptions(opts...)
+	var messageBuilder strings.Builder
+
+	if cfg.Message != "" {
+		messageBuilder.WriteString(cfg.Message)
+		messageBuilder.WriteString("\n")
+	}
+
+	if actual < min {
+		messageBuilder.WriteString(fmt.Sprintf("Expected value to be in range [%v, %v], but it was below:", min, max))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Value    : %v", actual))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Range    : [%v, %v]", min, max))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Distance : %v below minimum (%v < %v)", min-actual, actual, min))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Hint     : Value should be >= %v", min))
+	} else { // actual > max
+		messageBuilder.WriteString(fmt.Sprintf("Expected value to be in range [%v, %v], but it was above:", min, max))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Value    : %v", actual))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Range    : [%v, %v]", min, max))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Distance : %v above maximum (%v > %v)", actual-max, actual, max))
+		messageBuilder.WriteString(fmt.Sprintf("\n        Hint     : Value should be <= %v", max))
+	}
+
+	fail(t, messageBuilder.String())
+}
+
 // BeEqual reports a test failure if the two values are not deeply equal.
 //
 // This assertion uses Go's reflect.DeepEqual for comparison and provides detailed

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -448,28 +448,13 @@ func BeInRange[T Ordered](t testing.TB, actual T, min T, max T, opts ...Option) 
 	}
 
 	cfg := processOptions(opts...)
-	var messageBuilder strings.Builder
+	errorMsg := formatRangeError(actual, min, max)
 
 	if cfg.Message != "" {
-		messageBuilder.WriteString(cfg.Message)
-		messageBuilder.WriteString("\n")
+		fail(t, "%s\n%s", cfg.Message, errorMsg)
+		return
 	}
-
-	if actual < min {
-		messageBuilder.WriteString(fmt.Sprintf("Expected value to be in range [%v, %v], but it was below:", min, max))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Value    : %v", actual))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Range    : [%v, %v]", min, max))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Distance : %v below minimum (%v < %v)", min-actual, actual, min))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Hint     : Value should be >= %v", min))
-	} else { // actual > max
-		messageBuilder.WriteString(fmt.Sprintf("Expected value to be in range [%v, %v], but it was above:", min, max))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Value    : %v", actual))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Range    : [%v, %v]", min, max))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Distance : %v above maximum (%v > %v)", actual-max, actual, max))
-		messageBuilder.WriteString(fmt.Sprintf("\n        Hint     : Value should be <= %v", max))
-	}
-
-	fail(t, messageBuilder.String())
+	fail(t, errorMsg)
 }
 
 // BeEqual reports a test failure if the two values are not deeply equal.

--- a/assert/assetions_test.go
+++ b/assert/assetions_test.go
@@ -5112,15 +5112,6 @@ func TestBeInRange(t *testing.T) {
 				shouldFail:  true,
 				expectedMsg: "Expected value to be in range [0, 100], but it was above:",
 			},
-			{
-				name:        "should include custom message on failure",
-				value:       150,
-				min:         0,
-				max:         100,
-				opts:        []Option{WithMessage("Battery level must be valid")},
-				shouldFail:  true,
-				expectedMsg: "Battery level must be valid\nExpected value to be in range [0, 100], but it was above:",
-			},
 		}
 
 		for _, tt := range tests {
@@ -5185,5 +5176,40 @@ func TestBeInRange(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
+		t.Run("should include custom message on failure when below range", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+			opts := []Option{WithMessage("Value is out of bounds")}
+			BeInRange(mockT, 10, 20, 30, opts...)
+
+			if !mockT.Failed() {
+				t.Fatal("Expected test to fail, but it passed")
+			}
+
+			expectedMsg := "Value is out of bounds\nExpected value to be in range [20, 30], but it was below:"
+			if !strings.Contains(mockT.message, expectedMsg) {
+				t.Errorf("Expected error message to contain %q, but got %q", expectedMsg, mockT.message)
+			}
+		})
+
+		t.Run("should include custom message on failure when above range", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+			opts := []Option{WithMessage("Battery level must be valid")}
+			BeInRange(mockT, 150, 0, 100, opts...)
+
+			if !mockT.Failed() {
+				t.Fatal("Expected test to fail, but it passed")
+			}
+
+			expectedMsg := "Battery level must be valid\nExpected value to be in range [0, 100], but it was above:"
+			if !strings.Contains(mockT.message, expectedMsg) {
+				t.Errorf("Expected error message to contain %q, but got %q", expectedMsg, mockT.message)
+			}
+		})
 	})
 }

--- a/assert/assetions_test.go
+++ b/assert/assetions_test.go
@@ -5087,28 +5087,28 @@ func TestBeInRange(t *testing.T) {
 		tests := []struct {
 			name        string
 			value       int
-			min         int
-			max         int
+			minValue    int
+			maxValue    int
 			opts        []Option
 			shouldFail  bool
 			expectedMsg string
 		}{
-			{name: "should pass when value is within range", value: 50, min: 0, max: 100, shouldFail: false},
-			{name: "should pass when value is at lower bound", value: 0, min: 0, max: 100, shouldFail: false},
-			{name: "should pass when value is at upper bound", value: 100, min: 0, max: 100, shouldFail: false},
+			{name: "should pass when value is within range", value: 50, minValue: 0, maxValue: 100, shouldFail: false},
+			{name: "should pass when value is at lower bound", value: 0, minValue: 0, maxValue: 100, shouldFail: false},
+			{name: "should pass when value is at upper bound", value: 100, minValue: 0, maxValue: 100, shouldFail: false},
 			{
 				name:        "should fail when value is below range",
 				value:       16,
-				min:         18,
-				max:         65,
+				minValue:    18,
+				maxValue:    65,
 				shouldFail:  true,
 				expectedMsg: "Expected value to be in range [18, 65], but it was below:",
 			},
 			{
 				name:        "should fail when value is above range",
 				value:       105,
-				min:         0,
-				max:         100,
+				minValue:    0,
+				maxValue:    100,
 				shouldFail:  true,
 				expectedMsg: "Expected value to be in range [0, 100], but it was above:",
 			},
@@ -5117,7 +5117,7 @@ func TestBeInRange(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				mockT := &mockT{}
-				BeInRange(mockT, tt.value, tt.min, tt.max, tt.opts...)
+				BeInRange(mockT, tt.value, tt.minValue, tt.maxValue, tt.opts...)
 
 				if tt.shouldFail != mockT.Failed() {
 					t.Errorf("Expected test failure to be %v, but was %v", tt.shouldFail, mockT.Failed())
@@ -5136,27 +5136,27 @@ func TestBeInRange(t *testing.T) {
 		tests := []struct {
 			name        string
 			value       float64
-			min         float64
-			max         float64
+			minValue    float64
+			maxValue    float64
 			shouldFail  bool
 			expectedMsg string
 		}{
-			{name: "should pass when value is within range", value: 0.5, min: 0.0, max: 1.0, shouldFail: false},
-			{name: "should pass when value is at lower bound", value: 0.0, min: 0.0, max: 1.0, shouldFail: false},
-			{name: "should pass when value is at upper bound", value: 1.0, min: 0.0, max: 1.0, shouldFail: false},
+			{name: "should pass when value is within range", value: 0.5, minValue: 0.0, maxValue: 1.0, shouldFail: false},
+			{name: "should pass when value is at lower bound", value: 0.0, minValue: 0.0, maxValue: 1.0, shouldFail: false},
+			{name: "should pass when value is at upper bound", value: 1.0, minValue: 0.0, maxValue: 1.0, shouldFail: false},
 			{
 				name:        "should fail when value is below range",
 				value:       -0.1,
-				min:         0.0,
-				max:         1.0,
+				minValue:    0.0,
+				maxValue:    1.0,
 				shouldFail:  true,
 				expectedMsg: "Expected value to be in range [0, 1], but it was below:",
 			},
 			{
 				name:        "should fail when value is above range",
 				value:       1.1,
-				min:         0.0,
-				max:         1.0,
+				minValue:    0.0,
+				maxValue:    1.0,
 				shouldFail:  true,
 				expectedMsg: "Expected value to be in range [0, 1], but it was above:",
 			},
@@ -5165,7 +5165,7 @@ func TestBeInRange(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				mockT := &mockT{}
-				BeInRange(mockT, tt.value, tt.min, tt.max)
+				BeInRange(mockT, tt.value, tt.minValue, tt.maxValue)
 
 				if tt.shouldFail != mockT.Failed() {
 					t.Errorf("Expected test failure to be %v, but was %v", tt.shouldFail, mockT.Failed())

--- a/assert/assetions_test.go
+++ b/assert/assetions_test.go
@@ -5077,3 +5077,113 @@ func TestFail_Integration(t *testing.T) {
 		}
 	})
 }
+
+func TestBeInRange(t *testing.T) {
+	t.Parallel()
+
+	// Test cases for integer ranges
+	t.Run("Integer range", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name        string
+			value       int
+			min         int
+			max         int
+			opts        []Option
+			shouldFail  bool
+			expectedMsg string
+		}{
+			{name: "should pass when value is within range", value: 50, min: 0, max: 100, shouldFail: false},
+			{name: "should pass when value is at lower bound", value: 0, min: 0, max: 100, shouldFail: false},
+			{name: "should pass when value is at upper bound", value: 100, min: 0, max: 100, shouldFail: false},
+			{
+				name:        "should fail when value is below range",
+				value:       16,
+				min:         18,
+				max:         65,
+				shouldFail:  true,
+				expectedMsg: "Expected value to be in range [18, 65], but it was below:",
+			},
+			{
+				name:        "should fail when value is above range",
+				value:       105,
+				min:         0,
+				max:         100,
+				shouldFail:  true,
+				expectedMsg: "Expected value to be in range [0, 100], but it was above:",
+			},
+			{
+				name:        "should include custom message on failure",
+				value:       150,
+				min:         0,
+				max:         100,
+				opts:        []Option{WithMessage("Battery level must be valid")},
+				shouldFail:  true,
+				expectedMsg: "Battery level must be valid\nExpected value to be in range [0, 100], but it was above:",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				mockT := &mockT{}
+				BeInRange(mockT, tt.value, tt.min, tt.max, tt.opts...)
+
+				if tt.shouldFail != mockT.Failed() {
+					t.Errorf("Expected test failure to be %v, but was %v", tt.shouldFail, mockT.Failed())
+				}
+
+				if tt.shouldFail && !strings.Contains(mockT.message, tt.expectedMsg) {
+					t.Errorf("Expected error message to contain %q, but got %q", tt.expectedMsg, mockT.message)
+				}
+			})
+		}
+	})
+
+	// Test cases for float ranges
+	t.Run("Float range", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name        string
+			value       float64
+			min         float64
+			max         float64
+			shouldFail  bool
+			expectedMsg string
+		}{
+			{name: "should pass when value is within range", value: 0.5, min: 0.0, max: 1.0, shouldFail: false},
+			{name: "should pass when value is at lower bound", value: 0.0, min: 0.0, max: 1.0, shouldFail: false},
+			{name: "should pass when value is at upper bound", value: 1.0, min: 0.0, max: 1.0, shouldFail: false},
+			{
+				name:        "should fail when value is below range",
+				value:       -0.1,
+				min:         0.0,
+				max:         1.0,
+				shouldFail:  true,
+				expectedMsg: "Expected value to be in range [0, 1], but it was below:",
+			},
+			{
+				name:        "should fail when value is above range",
+				value:       1.1,
+				min:         0.0,
+				max:         1.0,
+				shouldFail:  true,
+				expectedMsg: "Expected value to be in range [0, 1], but it was above:",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				mockT := &mockT{}
+				BeInRange(mockT, tt.value, tt.min, tt.max)
+
+				if tt.shouldFail != mockT.Failed() {
+					t.Errorf("Expected test failure to be %v, but was %v", tt.shouldFail, mockT.Failed())
+				}
+
+				if tt.shouldFail && !strings.Contains(mockT.message, tt.expectedMsg) {
+					t.Errorf("Expected error message to contain %q, but got %q", tt.expectedMsg, mockT.message)
+				}
+			})
+		}
+	})
+}

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -2145,3 +2145,21 @@ func formatMapNotContainValueError(target interface{}, mapValue interface{}) str
 
 	return msg.String()
 }
+
+func formatRangeError[T Ordered](actual, min, max T) string {
+	if actual < min {
+		return fmt.Sprintf("Expected value to be in range [%v, %v], but it was below:"+
+			"\n        Value    : %v"+
+			"\n        Range    : [%v, %v]"+
+			"\n        Distance : %v below minimum (%v < %v)"+
+			"\n        Hint     : Value should be >= %v",
+			min, max, actual, min, max, min-actual, actual, min, min)
+	}
+
+	return fmt.Sprintf("Expected value to be in range [%v, %v], but it was above:"+
+		"\n        Value    : %v"+
+		"\n        Range    : [%v, %v]"+
+		"\n        Distance : %v above maximum (%v > %v)"+
+		"\n        Hint     : Value should be <= %v",
+		min, max, actual, min, max, actual-max, actual, max, max)
+}

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -2146,14 +2146,14 @@ func formatMapNotContainValueError(target interface{}, mapValue interface{}) str
 	return msg.String()
 }
 
-func formatRangeError[T Ordered](actual, min, max T) string {
-	if actual < min {
+func formatRangeError[T Ordered](actual, minValue, maxValue T) string {
+	if actual < minValue {
 		return fmt.Sprintf("Expected value to be in range [%v, %v], but it was below:"+
 			"\n        Value    : %v"+
 			"\n        Range    : [%v, %v]"+
 			"\n        Distance : %v below minimum (%v < %v)"+
 			"\n        Hint     : Value should be >= %v",
-			min, max, actual, min, max, min-actual, actual, min, min)
+			minValue, maxValue, actual, minValue, maxValue, minValue-actual, actual, minValue, minValue)
 	}
 
 	return fmt.Sprintf("Expected value to be in range [%v, %v], but it was above:"+
@@ -2161,5 +2161,5 @@ func formatRangeError[T Ordered](actual, min, max T) string {
 		"\n        Range    : [%v, %v]"+
 		"\n        Distance : %v above maximum (%v > %v)"+
 		"\n        Hint     : Value should be <= %v",
-		min, max, actual, min, max, actual-max, actual, max, max)
+		minValue, maxValue, actual, minValue, maxValue, actual-maxValue, actual, maxValue, maxValue)
 }

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -2633,3 +2633,75 @@ func TestRemoveDuplicateSimilarItems(t *testing.T) {
 		}
 	})
 }
+
+func TestFormatString(t *testing.T) {
+	// ... existing test ...
+}
+
+func TestFormatRangeError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("value below range", func(t *testing.T) {
+		t.Parallel()
+		actual := 16
+		min := 18
+		max := 65
+		expected := `Expected value to be in range [18, 65], but it was below:
+        Value    : 16
+        Range    : [18, 65]
+        Distance : 2 below minimum (16 < 18)
+        Hint     : Value should be >= 18`
+		result := formatRangeError(actual, min, max)
+		if result != expected {
+			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
+		}
+	})
+
+	t.Run("value above range", func(t *testing.T) {
+		t.Parallel()
+		actual := 105
+		min := 0
+		max := 100
+		expected := `Expected value to be in range [0, 100], but it was above:
+        Value    : 105
+        Range    : [0, 100]
+        Distance : 5 above maximum (105 > 100)
+        Hint     : Value should be <= 100`
+		result := formatRangeError(actual, min, max)
+		if result != expected {
+			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
+		}
+	})
+
+	t.Run("float value below range", func(t *testing.T) {
+		t.Parallel()
+		actual := -0.1
+		min := 0.0
+		max := 1.0
+		expected := fmt.Sprintf(`Expected value to be in range [%v, %v], but it was below:
+        Value    : %v
+        Range    : [%v, %v]
+        Distance : %v below minimum (%v < %v)
+        Hint     : Value should be >= %v`, min, max, actual, min, max, min-actual, actual, min, min)
+		result := formatRangeError(actual, min, max)
+		if result != expected {
+			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
+		}
+	})
+
+	t.Run("float value above range", func(t *testing.T) {
+		t.Parallel()
+		actual := 1.1
+		min := 0.0
+		max := 1.0
+		expected := fmt.Sprintf(`Expected value to be in range [%v, %v], but it was above:
+        Value    : %v
+        Range    : [%v, %v]
+        Distance : %v above maximum (%v > %v)
+        Hint     : Value should be <= %v`, min, max, actual, min, max, actual-max, actual, max, max)
+		result := formatRangeError(actual, min, max)
+		if result != expected {
+			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
+		}
+	})
+}

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -2644,14 +2644,14 @@ func TestFormatRangeError(t *testing.T) {
 	t.Run("value below range", func(t *testing.T) {
 		t.Parallel()
 		actual := 16
-		min := 18
-		max := 65
+		minValue := 18
+		maxValue := 65
 		expected := `Expected value to be in range [18, 65], but it was below:
         Value    : 16
         Range    : [18, 65]
         Distance : 2 below minimum (16 < 18)
         Hint     : Value should be >= 18`
-		result := formatRangeError(actual, min, max)
+		result := formatRangeError(actual, minValue, maxValue)
 		if result != expected {
 			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
 		}
@@ -2660,14 +2660,14 @@ func TestFormatRangeError(t *testing.T) {
 	t.Run("value above range", func(t *testing.T) {
 		t.Parallel()
 		actual := 105
-		min := 0
-		max := 100
+		minValue := 0
+		maxValue := 100
 		expected := `Expected value to be in range [0, 100], but it was above:
         Value    : 105
         Range    : [0, 100]
         Distance : 5 above maximum (105 > 100)
         Hint     : Value should be <= 100`
-		result := formatRangeError(actual, min, max)
+		result := formatRangeError(actual, minValue, maxValue)
 		if result != expected {
 			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
 		}
@@ -2676,14 +2676,14 @@ func TestFormatRangeError(t *testing.T) {
 	t.Run("float value below range", func(t *testing.T) {
 		t.Parallel()
 		actual := -0.1
-		min := 0.0
-		max := 1.0
+		minValue := 0.0
+		maxValue := 1.0
 		expected := fmt.Sprintf(`Expected value to be in range [%v, %v], but it was below:
         Value    : %v
         Range    : [%v, %v]
         Distance : %v below minimum (%v < %v)
-        Hint     : Value should be >= %v`, min, max, actual, min, max, min-actual, actual, min, min)
-		result := formatRangeError(actual, min, max)
+        Hint     : Value should be >= %v`, minValue, maxValue, actual, minValue, maxValue, minValue-actual, actual, minValue, minValue)
+		result := formatRangeError(actual, minValue, maxValue)
 		if result != expected {
 			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
 		}
@@ -2692,14 +2692,14 @@ func TestFormatRangeError(t *testing.T) {
 	t.Run("float value above range", func(t *testing.T) {
 		t.Parallel()
 		actual := 1.1
-		min := 0.0
-		max := 1.0
+		minValue := 0.0
+		maxValue := 1.0
 		expected := fmt.Sprintf(`Expected value to be in range [%v, %v], but it was above:
         Value    : %v
         Range    : [%v, %v]
         Distance : %v above maximum (%v > %v)
-        Hint     : Value should be <= %v`, min, max, actual, min, max, actual-max, actual, max, max)
-		result := formatRangeError(actual, min, max)
+        Hint     : Value should be <= %v`, minValue, maxValue, actual, minValue, maxValue, actual-maxValue, actual, maxValue, maxValue)
+		result := formatRangeError(actual, minValue, maxValue)
 		if result != expected {
 			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
 		}

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -2634,10 +2634,6 @@ func TestRemoveDuplicateSimilarItems(t *testing.T) {
 	})
 }
 
-func TestFormatString(t *testing.T) {
-	// ... existing test ...
-}
-
 func TestFormatRangeError(t *testing.T) {
 	t.Parallel()
 

--- a/should.go
+++ b/should.go
@@ -232,6 +232,26 @@ func BeLessOrEqualTo[T assert.Ordered](t testing.TB, actual T, expected T, opts 
 	assert.BeLessOrEqualTo(t, actual, expected, opts...)
 }
 
+// BeInRange reports a test failure if the value is not within the specified range (inclusive).
+//
+// This assertion works with all numeric types and provides detailed
+// error messages when the assertion fails, indicating whether the value is
+// above or below the range and by how much.
+//
+// Example:
+//
+//	should.BeInRange(t, 25, 18, 65)
+//
+//	should.BeInRange(t, 99.5, 0.0, 100.0)
+//
+//	should.BeInRange(t, 200, 200, 299, should.WithMessage("HTTP status should be 2xx"))
+//
+// Only works with numeric types. All values must be of the same type.
+func BeInRange[T assert.Ordered](t testing.TB, actual T, min T, max T, opts ...Option) {
+	t.Helper()
+	assert.BeInRange(t, actual, min, max, opts...)
+}
+
 // BeEqual reports a test failure if the two values are not deeply equal.
 //
 // This assertion uses Go's reflect.DeepEqual for comparison and provides detailed

--- a/should.go
+++ b/should.go
@@ -247,9 +247,9 @@ func BeLessOrEqualTo[T assert.Ordered](t testing.TB, actual T, expected T, opts 
 //	should.BeInRange(t, 200, 200, 299, should.WithMessage("HTTP status should be 2xx"))
 //
 // Only works with numeric types. All values must be of the same type.
-func BeInRange[T assert.Ordered](t testing.TB, actual T, min T, max T, opts ...Option) {
+func BeInRange[T assert.Ordered](t testing.TB, actual T, minValue T, maxValue T, opts ...Option) {
 	t.Helper()
-	assert.BeInRange(t, actual, min, max, opts...)
+	assert.BeInRange(t, actual, minValue, maxValue, opts...)
 }
 
 // BeEqual reports a test failure if the two values are not deeply equal.

--- a/should_test.go
+++ b/should_test.go
@@ -447,6 +447,22 @@ func TestWrappers(t *testing.T) {
 			t.Error("BeOneOf should fail")
 		}
 	})
+
+	// BeInRange
+	t.Run("BeInRange passes", func(t *testing.T) {
+		mockT := &mockTB{}
+		BeInRange(mockT, 5, 0, 10)
+		if mockT.failed {
+			t.Error("BeInRange should pass")
+		}
+	})
+	t.Run("BeInRange fails", func(t *testing.T) {
+		mockT := &mockTB{}
+		BeInRange(mockT, 15, 0, 10)
+		if !mockT.failed {
+			t.Error("BeInRange should fail")
+		}
+	})
 }
 
 func TestContainKey_Integration(t *testing.T) {


### PR DESCRIPTION
## Body:

This pull request introduces the BeInRange assertion, a new feature designed to simplify numeric range validation in tests. It provides a clear and concise way to assert that a value falls within an inclusive [min, max] range.

## Problem

Closes #12 

Previously, validating if a number was within a specific range required multiple assertions (e.g., BeGreaterOrEqualTo and BeLessOrEqualTo). This approach was verbose and produced generic error messages that didn't clearly state that a range check had failed. This is a common requirement for validating things like age (18-65), scores (0-100), or HTTP status codes (200-299).

## Solution

I have introduced a new assertion, BeInRange, that addresses this gap.
New Assertion:
assert.BeInRange[T Ordered] provides the core logic in assert/assertions.go.
should.BeInRange serves as the user-facing wrapper in should.go.
