### PR TITLE
Feat: HaveSameTimeAs

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: "stable"
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.3.0
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,37 +1,34 @@
+version: "2"
+
 run:
   timeout: 5m
   tests: true
 
-linters-settings:
-  gofmt:
-    simplify: true
-
-  goimports:
-    local-prefixes: github.com/Kairum-Labs/should
-
-  lll:
-    line-length: 120
-
-  misspell:
-    locale: US
-
 linters:
   enable:
     - errcheck
-    - gofmt
-    - goimports
     - govet
     - ineffassign
     - misspell
     - staticcheck
-    - typecheck
     - unused
-    - gosimple
+    - paralleltest
+    - lll
+  settings:
+    lll:
+      line-length: 130
+    misspell:
+      locale: US
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/Kairum-Labs/should
 
 issues:
-  exclude-rules:
-    # Allow long lines in test files
-    - path: _test\.go
-      text: "line is \\d+ characters"
-      linters:
-        - lll
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - **Detailed Error Messages**: Get comprehensive, contextual error information for every assertion type.
 - **Smart String Handling**: Automatic multiline formatting for long strings and truncation with context.
 - **Numeric Comparisons**: Detailed difference calculations with helpful hints for numeric assertions.
+- **Time Comparisons**: Compare times with options to ignore timezone and/or nanoseconds with clear diffs.
 - **Empty/Non-Empty Checks**: Rich context about collection types, sizes, and content.
 - **String Similarity**: When a string assertion fails, `Should` suggests similar strings from your collection to help you spot typos.
 - **Numeric Context**: When a numeric assertion fails, `Should` shows nearby values in the collection to help you reason about missing or unexpected numbers.
@@ -423,6 +424,46 @@ should.NotContainDuplicates(t, []int{1, 2, 2, 3, 3, 3})
 // └─ 3 appears 3 times at indexes [3, 4, 5]
 ```
 
+### Time Assertions
+
+Compare times with flexible options:
+
+```go
+// HaveSameTimeAs compares two time.Time values for equality
+
+// Basic usage
+should.HaveSameTimeAs(t, actual, expected)
+
+// With options
+should.HaveSameTimeAs(t, actual, expected,
+    should.WithIgnoreTimezone(),
+    should.WithIgnoreNanoseconds(),
+)
+
+time1 := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
+time2 := time.Date(2024, 1, 15, 14, 30, 2, 500000000, time.UTC)
+
+should.HaveSameTimeAs(t, time1, time2)
+// Expected times to have same time, but difference is 2.5s
+// Expected: 2024-01-15 14:30:00.000000000 UTC
+// Actual  : 2024-01-15 14:30:02.500000000 UTC (2.5s later)
+
+should.HaveSameTimeAs(t, time2, time1)
+// Expected times to have same time, but difference is 2.5s
+// Expected: 2024-01-15 14:30:00.000000000 UTC
+// Actual  : 2024-01-15 14:30:02.500000000 UTC (2.5s earlier)
+
+// Ignore timezone differences
+utc := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
+est := time.Date(2024, 1, 15, 9, 30, 0, 0, time.FixedZone("EST", -5*3600))
+should.HaveSameTimeAs(t, utc, est, should.WithIgnoreTimezone()) // Pass
+
+// Ignore nanosecond precision
+time1 = time.Date(2024, 1, 15, 14, 30, 0, 123456789, time.UTC)
+time2 = time.Date(2024, 1, 15, 14, 30, 0, 987654321, time.UTC)
+should.HaveSameTimeAs(t, time1, time2, should.WithIgnoreNanoseconds()) // Pass
+```
+
 ### Sorted Check
 
 Verify that collections are sorted in ascending order with detailed violation reporting:
@@ -563,6 +604,7 @@ should.NotContainValue(t, userRoles, 3)
 - `BeNil(t, actual)` / `NotBeNil(t, actual)` - Nil pointer checks
 - `BeOfType(t, actual, expected)` - Checks if a value is of a specific type
 - `HaveLength(t, collection, length)` - Checks if a collection has a specific length
+- `HaveSameTimeAs(t, actual, expected, options...)` - Compare times with optional timezone/nanosecond ignoring
 
 ### Empty/Non-Empty Checks
 
@@ -650,6 +692,30 @@ For `NotPanic` assert, you can capture detailed stack traces using `should.WithS
 should.NotPanic(t, func() {
     riskyOperation()
 }, should.WithStackTrace())
+```
+
+#### Time comparisons with `WithIgnoreTimezone` and `WithIgnoreNanoseconds`
+
+These options customize time comparisons for `HaveSameTimeAs`.
+
+- `should.WithIgnoreTimezone()`: compares instants regardless of timezone/location
+- `should.WithIgnoreNanoseconds()`: ignores sub-second differences
+
+```go
+// Ignore timezone while comparing the same instant represented in different locations
+t1 := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
+t2 := time.Date(2024, 1, 15, 16, 30, 0, 0, time.FixedZone("UTC+2", 2*3600))
+should.HaveSameTimeAs(t, t1, t2, should.WithIgnoreTimezone())
+
+// Ignore sub-second differences
+t3 := time.Date(2024, 1, 15, 14, 30, 2, 999_000_000, time.UTC)
+t4 := time.Date(2024, 1, 15, 14, 30, 2, 001_000_000, time.UTC)
+should.HaveSameTimeAs(t, t3, t4, should.WithIgnoreNanoseconds())
+
+// Combine both options
+should.HaveSameTimeAs(
+    t, t1, t2, should.WithIgnoreTimezone(), should.WithIgnoreNanoseconds(),
+)
 ```
 
 ### Custom Predicate Functions

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ func TestBasicAssertions(t *testing.T) {
 	should.Contain(t, users, "Alice")
 	should.NotContain(t, users, "David")
 	should.Contain(t, userIDs, targetID, should.WithMessage("User ID must exist in the system"))
+
+	// Sort check
+	should.BeSorted(t, []int{1, 2, 3, 4, 5})
+	should.BeSorted(t, []string{"apple", "banana", "cherry"})
+	should.BeSorted(t, scores, should.WithMessage("Test scores must be in ascending order"))
 }
 ```
 
@@ -418,6 +423,61 @@ should.NotContainDuplicates(t, []int{1, 2, 2, 3, 3, 3})
 // └─ 3 appears 3 times at indexes [3, 4, 5]
 ```
 
+### Sorted Check
+
+Verify that collections are sorted in ascending order with detailed violation reporting:
+
+```go
+// Multiple violations with helpful summary
+should.BeSorted(t, []int{5, 4, 3, 2, 1})
+// Output:
+// Expected collection to be in ascending order, but it is not:
+// Collection: (total: 5 elements)
+// Status    : 4 order violations found
+// Problems  :
+//   - Index 0: 5 > 4
+//   - Index 1: 4 > 3
+//   - Index 2: 3 > 2
+//   - Index 3: 2 > 1
+
+// Large collections with truncation (stops after 6 violations for performance)
+should.BeSorted(t, []int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0})
+// Output:
+// Expected collection to be in ascending order, but it is not:
+// Collection: (total: 11 elements)
+// Status    : 6 order violations found
+// Problems  :
+//   - Index 0: 10 > 9
+//   - Index 1: 9 > 8
+//   - Index 2: 8 > 7
+//   - Index 3: 7 > 6
+//   - Index 4: 6 > 5
+//   - ... and 1 more violation
+
+// Very large collections with special formatting
+should.BeSorted(t, largeSlice)
+// Output:
+// Expected collection to be in ascending order, but it is not:
+// Collection: [Large collection] (total: 10000 elements)
+// Status    : 3 order violations found
+// Problems  :
+//   - Index 4567: 123 > 115
+//   - Index 4702: 890 > 456
+//   - Index 4833: 234 > 111
+
+should.BeSorted(t, []string{"banana", "apple", "cherry"})
+// Output:
+// Expected collection to be in ascending order, but it is not:
+// Collection: (total: 3 elements)
+// Status    : 1 order violation found
+// Problems  :
+//   - Index 0: banana > apple
+
+// With custom messages
+should.BeSorted(t, testScores, should.WithMessage("Test scores must be in ascending order"))
+should.BeSorted(t, timestamps, should.WithMessage("Events must be chronologically ordered"))
+```
+
 ### Map Key and Value Assertions
 
 Check if maps contain specific keys or values with intelligent similarity detection:
@@ -530,6 +590,7 @@ should.NotContainValue(t, userRoles, 3)
 - `NotContain(t, collection, element)` - Check if slice/array does not contain an element
 - `NotContainDuplicates(t, collection)` - Check if slice/array contains no duplicate values
 - `ContainFunc(t, collection, predicate)` - Check if any element matches a custom predicate
+- `BeSorted(t, slice)` - Check if slice is sorted in ascending order (supports numeric types and strings)
 
 ### Map Operations
 
@@ -611,11 +672,11 @@ should.ContainFunc(t, people, func(item any) bool {
 
 // With custom error message
 should.ContainFunc(t, people, func(item any) bool {
-    person, ok := item.(Person)
-    if !ok {
-        return false
-    }
-    return person.Age >= 65
+	person, ok := item.(Person)
+	if !ok {
+		return false
+	}
+	return person.Age >= 65
 }, should.WithMessage("No elderly users found"))
 ```
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -799,7 +799,13 @@ func NotContainDuplicates(t testing.TB, actual any, opts ...Option) {
 			return
 		}
 
-		fail(t, "%s\nExpected no duplicates, but found %d duplicate values: %s", customMsg, len(duplicates), formatDuplicatesErrors(duplicates))
+		fail(
+			t,
+			"%s\nExpected no duplicates, but found %d duplicate values: %s",
+			customMsg,
+			len(duplicates),
+			formatDuplicatesErrors(duplicates),
+		)
 		return
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -458,47 +458,30 @@ func BeInRange[T Ordered](t testing.TB, actual T, minValue T, maxValue T, opts .
 	fail(t, errorMsg)
 }
 
-// BeSorted reports a test failure if the slice or array is not sorted in ascending order.
+// BeSorted reports a test failure if the slice is not sorted in ascending order.
 //
-// This assertion checks if all elements in the slice or array are in ascending order.
-// It provides detailed error messages showing order violations, including the index
-// and values that are out of order. For large collections, it shows a summary with
-// the total number of violations and displays up to 5 specific violations.
+// This assertion works with slices of any ordered type (integers, floats, strings).
+// For arrays, convert to slice using slice syntax: myArray[:].
+// Provides detailed error messages showing order violations with indices and values.
 //
 // Example:
 //
 //	should.BeSorted(t, []int{1, 2, 3, 4, 5})
 //
-//	should.BeSorted(t, [5]int{1, 2, 3, 4, 5})
+//	should.BeSorted(t, []string{"a", "b", "c"})
 //
-//	should.BeSorted(t, []float64{1.1, 2.2, 3.3}, should.WithMessage("Values must be in order"))
+//	should.BeSorted(t, myArray[:]) // for arrays
 //
-//	should.BeSorted(t, []string{"apple", "banana", "cherry"})
-//
-// Works with slices and arrays of sortable types (numeric types and strings)
-func BeSorted(t testing.TB, actual any, opts ...Option) {
+// Only works with slices of ordered types (cmp.Ordered constraint).
+func BeSorted[T Sortable](t testing.TB, actual []T, opts ...Option) {
 	t.Helper()
 
-	if !isSliceOrArray(actual) {
-		fail(t, "BeSorted can only be used with slices or arrays, but got %T", actual)
-		return
-	}
-
-	actualValue := reflect.ValueOf(actual)
-	if actualValue.Len() > 0 {
-		elemType := actualValue.Type().Elem()
-		if !isSortableElementType(elemType) {
-			fail(t, "BeSorted can only be used with sortable types, but got slice/array of %v", elemType)
-			return
-		}
-	}
-
+	cfg := processOptions(opts...)
 	result := checkIfSorted(actual)
 	if result.IsSorted {
 		return
 	}
 
-	cfg := processOptions(opts...)
 	errorMsg := formatSortError(result)
 	if cfg.Message != "" {
 		fail(t, "%s\n%s", cfg.Message, errorMsg)
@@ -1389,17 +1372,4 @@ func handleNumericSliceContain(collection any, target any) (found bool, output s
 	// Fallback for unsupported numeric types or type mismatches
 	return false, fmt.Sprintf("Expected collection to contain element:\n  Collection: %s\n  Missing   : %s",
 		formatSlice(collection), formatComparisonValue(target))
-}
-
-// isSortableElementType checks if a reflect.Type represents a sortable type
-func isSortableElementType(t reflect.Type) bool {
-	switch t.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
-		reflect.Float32, reflect.Float64,
-		reflect.String:
-		return true
-	default:
-		return false
-	}
 }

--- a/assert/assetions_test.go
+++ b/assert/assetions_test.go
@@ -3,6 +3,7 @@ package assert
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBeTrue_Succeeds_WhenTrue(t *testing.T) {
@@ -3294,6 +3295,278 @@ func TestHaveLength(t *testing.T) {
 		if !strings.Contains(mockT.message, expectedMsg) {
 			t.Errorf("Expected error message to contain %q, but got %q", expectedMsg, mockT.message)
 		}
+	})
+}
+
+func TestHaveSameTimeAs(t *testing.T) {
+	t.Parallel()
+
+	// Helper times for testing
+	baseTime := time.Date(2023, 12, 25, 15, 30, 45, 123456789, time.UTC)
+	sameTimeUTC := time.Date(2023, 12, 25, 15, 30, 45, 123456789, time.UTC)
+	sameTimeEST := time.Date(2023, 12, 25, 10, 30, 45, 123456789, time.FixedZone("EST", -5*3600))
+	differentTime := time.Date(2023, 12, 25, 15, 30, 46, 123456789, time.UTC)
+	sameTimeNoNanos := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
+	differentNanos := time.Date(2023, 12, 25, 15, 30, 45, 987654321, time.UTC)
+
+	t.Run("Basic functionality", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			actual     time.Time
+			expected   time.Time
+			opts       []Option
+			shouldFail bool
+		}{
+			{
+				name:       "exact same time should pass",
+				actual:     baseTime,
+				expected:   sameTimeUTC,
+				shouldFail: false,
+			},
+			{
+				name:       "different times should fail",
+				actual:     baseTime,
+				expected:   differentTime,
+				shouldFail: true,
+			},
+			{
+				name:       "same time different timezone should pass without options",
+				actual:     baseTime,
+				expected:   sameTimeEST,
+				shouldFail: false, // Same instant, different representation
+			},
+			{
+				name:       "same time different timezone should pass with IgnoreTimezone",
+				actual:     baseTime,
+				expected:   sameTimeEST,
+				opts:       []Option{WithIgnoreTimezone()},
+				shouldFail: false,
+			},
+			{
+				name:       "different nanoseconds should fail without options",
+				actual:     baseTime,
+				expected:   differentNanos,
+				shouldFail: true,
+			},
+			{
+				name:       "different nanoseconds should pass with IgnoreNanoseconds",
+				actual:     baseTime,
+				expected:   differentNanos,
+				opts:       []Option{WithIgnoreNanoseconds()},
+				shouldFail: false,
+			},
+			{
+				name:       "same time without nanoseconds should pass with IgnoreNanoseconds",
+				actual:     baseTime,
+				expected:   sameTimeNoNanos,
+				opts:       []Option{WithIgnoreNanoseconds()},
+				shouldFail: false,
+			},
+			{
+				name:       "both timezone and nanoseconds ignored",
+				actual:     time.Date(2023, 12, 25, 15, 30, 45, 123456789, time.UTC),
+				expected:   time.Date(2023, 12, 25, 10, 30, 45, 987654321, time.FixedZone("EST", -5*3600)),
+				opts:       []Option{WithIgnoreTimezone(), WithIgnoreNanoseconds()},
+				shouldFail: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				mockT := &mockT{}
+				HaveSameTimeAs(mockT, tt.actual, tt.expected, tt.opts...)
+
+				if tt.shouldFail && !mockT.failed {
+					t.Fatal("Expected test to fail, but it passed")
+				}
+				if !tt.shouldFail && mockT.failed {
+					t.Errorf("Expected test to pass, but it failed: %s", mockT.message)
+				}
+			})
+		}
+	})
+
+	t.Run("Options handling", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("WithIgnoreTimezone works correctly", func(t *testing.T) {
+			t.Parallel()
+			// Different timezone representations of the same instant
+			utcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			estTime := time.Date(2023, 1, 1, 7, 0, 0, 0, time.FixedZone("EST", -5*3600))
+
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, utcTime, estTime, WithIgnoreTimezone())
+
+			if mockT.failed {
+				t.Errorf("Same instant in different timezones should pass with IgnoreTimezone: %s", mockT.message)
+			}
+		})
+
+		t.Run("WithIgnoreNanoseconds truncates properly", func(t *testing.T) {
+			t.Parallel()
+			t1 := time.Date(2023, 1, 1, 12, 0, 0, 999999999, time.UTC)
+			t2 := time.Date(2023, 1, 1, 12, 0, 0, 1, time.UTC)
+
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, t1, t2, WithIgnoreNanoseconds())
+
+			if mockT.failed {
+				t.Errorf("Times should be equal when ignoring nanoseconds: %s", mockT.message)
+			}
+		})
+
+		t.Run("Multiple options work together", func(t *testing.T) {
+			t.Parallel()
+			t1 := time.Date(2023, 6, 15, 14, 30, 25, 123456789, time.UTC)
+			t2 := time.Date(2023, 6, 15, 9, 30, 25, 987654321, time.FixedZone("EST", -5*3600))
+
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, t1, t2, WithIgnoreTimezone(), WithIgnoreNanoseconds())
+
+			if mockT.failed {
+				t.Errorf("Times should be equal with both options: %s", mockT.message)
+			}
+		})
+
+		t.Run("WithMessage formats correctly", func(t *testing.T) {
+			t.Parallel()
+			t1 := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			t2 := time.Date(2023, 1, 1, 12, 0, 1, 0, time.UTC)
+
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, t1, t2, WithMessage("Time validation failed"))
+
+			if !mockT.failed {
+				t.Fatal("Expected test to fail")
+			}
+
+			if !strings.Contains(mockT.message, "Time validation failed") {
+				t.Errorf("Error message should contain custom message, got: %s", mockT.message)
+			}
+		})
+	})
+
+	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("zero times", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, time.Time{}, time.Time{})
+
+			if mockT.failed {
+				t.Errorf("Zero times should be equal: %s", mockT.message)
+			}
+		})
+
+		t.Run("zero vs non-zero time", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, time.Time{}, time.Now())
+
+			if !mockT.failed {
+				t.Error("Zero time should not equal non-zero time")
+			}
+		})
+
+		t.Run("daylight saving time transitions", func(t *testing.T) {
+			t.Parallel()
+			// Test DST transitions - times that are NOT the same instant
+			loc, err := time.LoadLocation("America/New_York")
+			if err != nil {
+				t.Skip("Could not load timezone data")
+			}
+
+			// These are different actual times
+			beforeDST := time.Date(2023, 3, 12, 1, 30, 0, 0, loc)
+			afterDST := time.Date(2023, 3, 12, 3, 30, 0, 0, loc)
+
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, beforeDST, afterDST)
+
+			if !mockT.failed {
+				t.Error("Different DST times should not be equal")
+			}
+		})
+
+		t.Run("maximum time difference", func(t *testing.T) {
+			t.Parallel()
+			t1 := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+			t2 := time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
+
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, t1, t2)
+
+			if !mockT.failed {
+				t.Error("Maximum time difference should fail")
+			}
+
+			// Just verify we got an error message
+			if len(mockT.message) == 0 {
+				t.Error("Error message should not be empty for large time differences")
+			}
+		})
+
+		t.Run("nanosecond precision edge cases", func(t *testing.T) {
+			t.Parallel()
+			// Times that differ by exactly 1 nanosecond
+			t1 := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			t2 := time.Date(2023, 1, 1, 12, 0, 0, 1, time.UTC)
+
+			// Without ignoring nanoseconds - should fail
+			mockT1 := &mockT{}
+			HaveSameTimeAs(mockT1, t1, t2)
+			if !mockT1.failed {
+				t.Error("Times differing by 1ns should fail without IgnoreNanoseconds")
+			}
+
+			// With ignoring nanoseconds - should pass
+			mockT2 := &mockT{}
+			HaveSameTimeAs(mockT2, t1, t2, WithIgnoreNanoseconds())
+			if mockT2.failed {
+				t.Errorf("Times should be equal when ignoring nanoseconds: %s", mockT2.message)
+			}
+		})
+
+		t.Run("timezone offset edge cases", func(t *testing.T) {
+			t.Parallel()
+			// Test extreme timezone offsets - SAME INSTANT
+			utc := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			// Same instant in UTC+14
+			plus14 := utc.In(time.FixedZone("UTC+14", 14*3600))
+			// Same instant in UTC-12
+			minus12 := utc.In(time.FixedZone("UTC-12", -12*3600))
+
+			// These should pass even without IgnoreTimezone because they're the same instant
+			mockT1 := &mockT{}
+			HaveSameTimeAs(mockT1, utc, plus14)
+			if mockT1.failed {
+				t.Errorf("Same instant should pass regardless of timezone representation: %s", mockT1.message)
+			}
+
+			mockT2 := &mockT{}
+			HaveSameTimeAs(mockT2, utc, minus12)
+			if mockT2.failed {
+				t.Errorf("Same instant should pass regardless of timezone representation: %s", mockT2.message)
+			}
+		})
+
+		t.Run("different calendar dates same instant", func(t *testing.T) {
+			t.Parallel()
+			// Test case where calendar dates differ but it's the same instant
+			utc := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+			// Same instant, but previous day in a western timezone
+			west := time.Date(2022, 12, 31, 14, 0, 0, 0, time.FixedZone("UTC-10", -10*3600))
+
+			mockT := &mockT{}
+			HaveSameTimeAs(mockT, utc, west)
+
+			if mockT.failed {
+				t.Errorf("Same instant should pass even with different calendar dates: %s", mockT.message)
+			}
+		})
 	})
 }
 

--- a/assert/assetions_test.go
+++ b/assert/assetions_test.go
@@ -5338,3 +5338,112 @@ func TestBeInRange(t *testing.T) {
 		})
 	})
 }
+
+func TestBeSorted(t *testing.T) {
+	// Helper function to reduce repetition
+	runSortTest := func(collection any, shouldFail bool, msgCheck string) {
+		mockTest := &mockT{}
+		BeSorted(mockTest, collection)
+
+		if shouldFail && !mockTest.Failed() {
+			t.Error("Expected failure but test passed")
+		}
+		if !shouldFail && mockTest.Failed() {
+			t.Errorf("Expected success but test failed: %s", mockTest.message)
+		}
+		if msgCheck != "" && mockTest.failed && !strings.Contains(mockTest.message, msgCheck) {
+			t.Errorf("Expected message to contain %q, got:\n%s", msgCheck, mockTest.message)
+		}
+	}
+
+	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
+
+		// Successful cases
+		runSortTest([]int{}, false, "")               // empty
+		runSortTest([]int{42}, false, "")             // single element
+		runSortTest([]int{1, 2, 3, 4, 5}, false, "")  // sorted
+		runSortTest([5]int{1, 2, 3, 4, 5}, false, "") // sorted array
+		runSortTest([]int{5, 5, 5}, false, "")        // duplicates
+
+		// Failure cases
+		runSortTest([]int{3, 1, 2}, true, "Index 0: 3 > 1")
+		runSortTest([3]int{3, 1, 2}, true, "Index 0: 3 > 1")
+		runSortTest([]int{5, 4, 3, 2, 1}, true, "4 order violations found")
+	})
+
+	t.Run("Type variations", func(t *testing.T) {
+		t.Parallel()
+
+		// Different types - sorted
+		runSortTest([]float64{1.1, 2.2, 3.3}, false, "")
+		runSortTest([]string{"apple", "banana", "cherry"}, false, "")
+		runSortTest([3]string{"apple", "banana", "cherry"}, false, "")
+
+		// Different types - unsorted
+		runSortTest([]float64{1.1, 3.3, 2.2}, true, "Index 1: 3.3 > 2.2")
+		runSortTest([]string{"banana", "apple"}, true, "Index 0: banana > apple")
+	})
+
+	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
+
+		runSortTest([]int{-5, -3, -1, 0, 2}, false, "")         // negatives sorted
+		runSortTest([]int{-1, -5, 0}, true, "Index 0: -1 > -5") // negatives unsorted
+		runSortTest([]float64{1.0, 1.1, 1.2}, false, "")        // float precision
+	})
+
+	t.Run("Error cases", func(t *testing.T) {
+		t.Parallel()
+
+		nonCollectionMock := &mockT{}
+		BeSorted(nonCollectionMock, 42) // not slice/array
+		if !nonCollectionMock.Failed() || !strings.Contains(nonCollectionMock.message, "slices or arrays") {
+			t.Errorf("Expected error for non-slice/array type")
+		}
+
+		unsortableTypeMock := &mockT{}
+		type unsortable struct{ value int }
+		BeSorted(unsortableTypeMock, []unsortable{{1}, {2}}) // unsortable elements
+		if !unsortableTypeMock.Failed() || !strings.Contains(unsortableTypeMock.message, "sortable types") {
+			t.Errorf("Expected error for unsortable element type")
+		}
+	})
+
+	t.Run("Large collection", func(t *testing.T) {
+		t.Parallel()
+
+		largeSlice := generateUnsortedLargeSlice(1000)
+		runSortTest(largeSlice, true, "[Large collection]")
+	})
+
+	t.Run("Custom message", func(t *testing.T) {
+		t.Parallel()
+
+		customMessageMock := &mockT{}
+		customMsg := "Values must be in order"
+		BeSorted(customMessageMock, []int{3, 1, 2}, WithMessage(customMsg))
+
+		if !customMessageMock.Failed() {
+			t.Error("Expected failure but test passed")
+		}
+		if !strings.Contains(customMessageMock.message, customMsg) {
+			t.Errorf("Expected custom message in error")
+		}
+	})
+}
+
+// generateUnsortedLargeSlice creates a large slice with some violations for testing
+func generateUnsortedLargeSlice(size int) []int {
+	slice := make([]int, size)
+	for i := range size {
+		slice[i] = i
+	}
+	// Add some violations
+	if size > 10 {
+		slice[5] = slice[5] + 10           // Make element 5 larger
+		slice[size/2] = slice[size/2] - 10 // Make middle element smaller
+		slice[size-5] = slice[size-5] - 20 // Make near-end element smaller
+	}
+	return slice
+}

--- a/assert/assetions_test.go
+++ b/assert/assetions_test.go
@@ -127,6 +127,7 @@ func TestNotBeEqual(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     interface{}
@@ -178,6 +179,7 @@ func TestNotBeEqual(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				NotBeEqual(mockT, tt.actual, tt.expected)
 
@@ -195,6 +197,7 @@ func TestNotBeEqual(t *testing.T) {
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     interface{}
@@ -226,6 +229,7 @@ func TestNotBeEqual(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				NotBeEqual(mockT, tt.actual, tt.expected, tt.opts...)
 
@@ -243,6 +247,7 @@ func TestNotBeEqual(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     interface{}
@@ -320,6 +325,7 @@ func TestNotBeEqual(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				NotBeEqual(mockT, tt.actual, tt.expected)
 
@@ -600,6 +606,7 @@ func TestContain_WithIntSlices(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			if tc.expected {
 				// Should pass
 				Contain(t, tc.slice, tc.target)
@@ -668,6 +675,7 @@ func TestBeEmpty_Succeeds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			BeEmpty(t, tt.value)
 		})
 	}
@@ -1343,6 +1351,7 @@ func TestNotPanic_Extended(t *testing.T) {
 	t.Parallel()
 
 	t.Run("With WithStackTrace option", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name          string
 			testFunc      func()
@@ -1375,8 +1384,8 @@ func TestNotPanic_Extended(t *testing.T) {
 			{
 				name: "should fail with stack trace when runtime panic occurs",
 				testFunc: func() {
-					var x int = 1
-					var y int = 0
+					x := 1
+					y := 0
 					result := x / y
 					_ = result
 				},
@@ -1392,6 +1401,7 @@ func TestNotPanic_Extended(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				if tt.shouldFail {
 					failed, message := assertFails(t, func(t testing.TB) {
 						NotPanic(t, tt.testFunc, tt.opts...)
@@ -1414,6 +1424,7 @@ func TestNotPanic_Extended(t *testing.T) {
 	})
 
 	t.Run("Combined options", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name          string
 			testFunc      func()
@@ -1442,6 +1453,7 @@ func TestNotPanic_Extended(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				if tt.shouldFail {
 					failed, message := assertFails(t, func(t testing.TB) {
 						NotPanic(t, tt.testFunc, tt.opts...)
@@ -1551,7 +1563,10 @@ func TestBeGreaterOrEqualTo_Fails_WithMixedIntFloat(t *testing.T) {
 // === Tests for BeLessOrEqualTo ===
 
 func TestBeLessOrEqualTo(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		// Integer tests
 		BeLessOrEqualTo(t, 5, 10)
 		BeLessOrEqualTo(t, 10, 10)
@@ -1562,6 +1577,7 @@ func TestBeLessOrEqualTo(t *testing.T) {
 
 		// Test failures
 		t.Run("Fails when actual is greater than expected", func(t *testing.T) {
+			t.Parallel()
 			failed, message := assertFails(t, func(t testing.TB) {
 				BeLessOrEqualTo(t, 15, 10)
 			})
@@ -1585,6 +1601,7 @@ func TestBeLessOrEqualTo(t *testing.T) {
 		})
 
 		t.Run("Fails with float precision", func(t *testing.T) {
+			t.Parallel()
 			failed, message := assertFails(t, func(t testing.TB) {
 				BeLessOrEqualTo(t, 3.15, 3.14)
 			})
@@ -1608,11 +1625,13 @@ func TestBeLessOrEqualTo(t *testing.T) {
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
 		// Success with custom message
 		BeLessOrEqualTo(t, 5, 10, WithMessage("Value should be within limit"))
 
 		// Fails with custom error message
 		t.Run("Fails with custom error message", func(t *testing.T) {
+			t.Parallel()
 			failed, message := assertFails(t, func(t testing.TB) {
 				BeLessOrEqualTo(t, 100, 50, WithMessage("Score should not exceed maximum"))
 			})
@@ -1636,6 +1655,7 @@ func TestBeLessOrEqualTo(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		// Success with zero values
 		BeLessOrEqualTo(t, 0, 0)
 
@@ -1647,6 +1667,7 @@ func TestBeLessOrEqualTo(t *testing.T) {
 
 		// Fails with negative comparison
 		t.Run("Fails with negative comparison", func(t *testing.T) {
+			t.Parallel()
 			failed, message := assertFails(t, func(t testing.TB) {
 				BeLessOrEqualTo(t, -5, -10)
 			})
@@ -1670,6 +1691,7 @@ func TestBeLessOrEqualTo(t *testing.T) {
 	})
 
 	t.Run("Type compatibility", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			testFunc   func()
@@ -2332,7 +2354,11 @@ func TestNotContainDuplicates_Fails_WhenDuplicatesExist(t *testing.T) {
 
 	// Test that it correctly identifies duplicates in int slice
 	failed, message := assertFails(t, func(t testing.TB) {
-		NotContainDuplicates(t, []int{1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4}, WithMessage("Expected no duplicates, but found 1 duplicate value: 2"))
+		NotContainDuplicates(
+			t,
+			[]int{1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4},
+			WithMessage("Expected no duplicates, but found 1 duplicate value: 2"),
+		)
 	})
 	if !failed {
 		t.Fatal("Expected test to fail due to duplicates, but it passed")
@@ -2528,6 +2554,7 @@ func TestStartsWith(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2569,6 +2596,7 @@ func TestStartsWith(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				StartWith(mockT, tt.actual, tt.expected)
 
@@ -2586,6 +2614,7 @@ func TestStartsWith(t *testing.T) {
 	})
 
 	t.Run("Case sensitivity", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2616,6 +2645,7 @@ func TestStartsWith(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				StartWith(mockT, tt.actual, tt.expected, tt.opts...)
 
@@ -2633,6 +2663,7 @@ func TestStartsWith(t *testing.T) {
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2651,6 +2682,7 @@ func TestStartsWith(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				StartWith(mockT, tt.actual, tt.expected, tt.opts...)
 
@@ -2665,6 +2697,7 @@ func TestStartsWith(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2704,8 +2737,8 @@ func TestStartsWith(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				StartWith(mockT, tt.actual, tt.expected)
 
@@ -2723,6 +2756,7 @@ func TestStartsWith(t *testing.T) {
 	})
 
 	t.Run("String truncation", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2768,6 +2802,7 @@ func TestStartsWith(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				StartWith(mockT, tt.actual, tt.expected)
 
@@ -2788,7 +2823,10 @@ func TestStartsWith(t *testing.T) {
 // === Tests for EndWith ===
 
 func TestEndsWith(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2855,6 +2893,7 @@ func TestEndsWith(t *testing.T) {
 	})
 
 	t.Run("Case sensitivity", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2896,7 +2935,9 @@ func TestEndsWith(t *testing.T) {
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Fails with custom message", func(t *testing.T) {
+			t.Parallel()
 			mockT := &mockT{}
 			EndWith(mockT, "Hello, world!", "planet", WithMessage("String should end with 'planet'"))
 
@@ -2918,6 +2959,7 @@ func TestEndsWith(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -2962,6 +3004,7 @@ func TestEndsWith(t *testing.T) {
 	})
 
 	t.Run("String truncation", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -3089,42 +3132,52 @@ func TestNumericTypeConversions_AllTypes(t *testing.T) {
 
 	// Test all supported numeric types for better compareOrderable coverage
 	t.Run("int8", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, int8(10), int8(9))
 	})
 
 	t.Run("int16", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, int16(20), int16(19))
 	})
 
 	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, int32(30), int32(29))
 	})
 
 	t.Run("int64", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, int64(40), int64(39))
 	})
 
 	t.Run("uint8", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, uint8(50), uint8(49))
 	})
 
 	t.Run("uint16", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, uint16(60), uint16(59))
 	})
 
 	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, uint32(70), uint32(69))
 	})
 
 	t.Run("uint64", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, uint64(80), uint64(79))
 	})
 
 	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, float32(3.14), float32(3.13))
 	})
 
 	t.Run("float64", func(t *testing.T) {
+		t.Parallel()
 		BeGreaterThan(t, float64(2.718), float64(2.717))
 	})
 }
@@ -3159,7 +3212,10 @@ func TestIsNumericType_Coverage(t *testing.T) {
 // === Tests for HaveLength ===
 
 func TestHaveLength(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should pass for correct length of slice", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		HaveLength(mockT, []int{1, 2, 3}, 3)
 		if mockT.failed {
@@ -3168,6 +3224,7 @@ func TestHaveLength(t *testing.T) {
 	})
 
 	t.Run("should pass for correct length of string", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		HaveLength(mockT, "abc", 3)
 		if mockT.failed {
@@ -3176,6 +3233,7 @@ func TestHaveLength(t *testing.T) {
 	})
 
 	t.Run("should pass for correct length of map", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		HaveLength(mockT, map[int]int{1: 1, 2: 2}, 2)
 		if mockT.failed {
@@ -3184,6 +3242,7 @@ func TestHaveLength(t *testing.T) {
 	})
 
 	t.Run("should fail for incorrect length with custom message", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		HaveLength(mockT, []int{1, 2}, 3, WithMessage("Custom message"))
 		if !mockT.failed {
@@ -3196,6 +3255,7 @@ func TestHaveLength(t *testing.T) {
 	})
 
 	t.Run("should fail for incorrect length and show detailed error", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		HaveLength(mockT, []int{1, 2}, 3)
 		if !mockT.failed {
@@ -3212,6 +3272,7 @@ func TestHaveLength(t *testing.T) {
 	})
 
 	t.Run("should fail for incorrect length (more elements)", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		HaveLength(mockT, []int{1, 2, 3, 4}, 3)
 		if !mockT.failed {
@@ -3223,6 +3284,7 @@ func TestHaveLength(t *testing.T) {
 	})
 
 	t.Run("should fail for unsupported type", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		HaveLength(mockT, 123, 1)
 		if !mockT.failed {
@@ -3238,10 +3300,12 @@ func TestHaveLength(t *testing.T) {
 // === Tests for BeOfType ===
 
 func TestBeOfType(t *testing.T) {
+	t.Parallel()
 	type Cat struct{ Name string }
 	type Dog struct{ Name string }
 
 	t.Run("should pass for same type", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		var c *Cat
 		BeOfType(mockT, &Cat{}, c)
@@ -3251,6 +3315,7 @@ func TestBeOfType(t *testing.T) {
 	})
 
 	t.Run("should fail for different types", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		var d *Dog
 		BeOfType(mockT, &Cat{Name: "Whiskers"}, d)
@@ -3268,6 +3333,7 @@ func TestBeOfType(t *testing.T) {
 	})
 
 	t.Run("should pass for primitive types", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		BeOfType(mockT, 1, 0) // int and int
 		if mockT.failed {
@@ -3276,6 +3342,7 @@ func TestBeOfType(t *testing.T) {
 	})
 
 	t.Run("should fail for different primitive types", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		BeOfType(mockT, int32(1), int64(0))
 		if !mockT.failed {
@@ -3292,7 +3359,10 @@ func TestBeOfType(t *testing.T) {
 // === Tests for BeOneOf ===
 
 func TestBeOneOf(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should pass if value is one of the options", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		options := []string{"active", "inactive"}
 		BeOneOf(mockT, "active", options)
@@ -3302,6 +3372,7 @@ func TestBeOneOf(t *testing.T) {
 	})
 
 	t.Run("should fail if value is not one of the options", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		options := []string{"active", "inactive", "suspended"}
 		BeOneOf(mockT, "pending", options)
@@ -3318,6 +3389,7 @@ func TestBeOneOf(t *testing.T) {
 	})
 
 	t.Run("should fail for empty options", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		BeOneOf(mockT, "any", []string{})
 		if !mockT.failed {
@@ -3329,6 +3401,7 @@ func TestBeOneOf(t *testing.T) {
 	})
 
 	t.Run("should truncate long option lists in the error message", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		options := []string{"active", "inactive", "suspended", "deleted", "archived"}
 		BeOneOf(mockT, "pending", options)
@@ -3742,7 +3815,9 @@ func TestNotContainKey(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		t.Run("string keys", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]int
@@ -3786,6 +3861,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -3802,6 +3878,7 @@ func TestNotContainKey(t *testing.T) {
 		})
 
 		t.Run("int keys", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[int]string
@@ -3838,6 +3915,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -3854,6 +3932,7 @@ func TestNotContainKey(t *testing.T) {
 		})
 
 		t.Run("custom struct keys", func(t *testing.T) {
+			t.Parallel()
 			type CustomKey struct {
 				ID   int
 				Name string
@@ -3881,6 +3960,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -3895,7 +3975,9 @@ func TestNotContainKey(t *testing.T) {
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
 		t.Run("string-int maps", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]int
@@ -3915,6 +3997,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key, tt.opts...)
 					if tt.shouldFail && !mockT.Failed() {
@@ -3931,6 +4014,7 @@ func TestNotContainKey(t *testing.T) {
 		})
 
 		t.Run("string-string maps", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]string
@@ -3958,6 +4042,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key, tt.opts...)
 					if tt.shouldFail && !mockT.Failed() {
@@ -3975,7 +4060,9 @@ func TestNotContainKey(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		t.Run("nil map handling", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]int
@@ -3992,6 +4079,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -4005,6 +4093,7 @@ func TestNotContainKey(t *testing.T) {
 		})
 
 		t.Run("zero value keys", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[int]string
@@ -4027,6 +4116,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -4040,6 +4130,7 @@ func TestNotContainKey(t *testing.T) {
 		})
 
 		t.Run("empty string keys", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]int
@@ -4062,6 +4153,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -4075,6 +4167,7 @@ func TestNotContainKey(t *testing.T) {
 		})
 
 		t.Run("complex key types", func(t *testing.T) {
+			t.Parallel()
 			type ComplexKey struct {
 				ID   int
 				Name string
@@ -4102,6 +4195,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -4115,6 +4209,7 @@ func TestNotContainKey(t *testing.T) {
 		})
 
 		t.Run("pointer keys", func(t *testing.T) {
+			t.Parallel()
 			key1 := "test1"
 			key2 := "test2"
 			key3 := "test3"
@@ -4141,6 +4236,7 @@ func TestNotContainKey(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainKey(mockT, tt.mapValue, tt.key)
 					if tt.shouldFail && !mockT.Failed() {
@@ -4161,7 +4257,9 @@ func TestNotContainValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		t.Run("string-int maps", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]int
@@ -4205,6 +4303,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value)
 					if tt.shouldFail && !mockT.Failed() {
@@ -4221,6 +4320,7 @@ func TestNotContainValue(t *testing.T) {
 		})
 
 		t.Run("int-string maps", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[int]string
@@ -4257,6 +4357,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value)
 					if tt.shouldFail && !mockT.Failed() {
@@ -4274,7 +4375,9 @@ func TestNotContainValue(t *testing.T) {
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
 		t.Run("string to int map", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]int
@@ -4309,6 +4412,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value, tt.opts...)
 
@@ -4326,6 +4430,7 @@ func TestNotContainValue(t *testing.T) {
 		})
 
 		t.Run("string to string map", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]string
@@ -4360,6 +4465,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value, tt.opts...)
 
@@ -4377,6 +4483,7 @@ func TestNotContainValue(t *testing.T) {
 		})
 
 		t.Run("int to string map", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[int]string
@@ -4411,6 +4518,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value, tt.opts...)
 
@@ -4429,7 +4537,9 @@ func TestNotContainValue(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		t.Run("string-int maps", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[string]int
@@ -4470,6 +4580,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value)
 
@@ -4487,6 +4598,7 @@ func TestNotContainValue(t *testing.T) {
 		})
 
 		t.Run("int-string maps", func(t *testing.T) {
+			t.Parallel()
 			tests := []struct {
 				name       string
 				mapValue   map[int]string
@@ -4510,6 +4622,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value)
 
@@ -4527,6 +4640,7 @@ func TestNotContainValue(t *testing.T) {
 		})
 
 		t.Run("complex struct values", func(t *testing.T) {
+			t.Parallel()
 			type User struct{ Name string }
 
 			tests := []struct {
@@ -4580,6 +4694,7 @@ func TestNotContainValue(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					mockT := &mockT{}
 					NotContainValue(mockT, tt.mapValue, tt.value)
 
@@ -4625,6 +4740,7 @@ func TestContainSubstring(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -4679,6 +4795,7 @@ func TestContainSubstring(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				ContainSubstring(mockT, tt.actual, tt.substring)
 
@@ -4696,6 +4813,7 @@ func TestContainSubstring(t *testing.T) {
 	})
 
 	t.Run("Case sensitivity", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -4733,6 +4851,7 @@ func TestContainSubstring(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				ContainSubstring(mockT, tt.actual, tt.substring, tt.opts...)
 
@@ -4750,6 +4869,7 @@ func TestContainSubstring(t *testing.T) {
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -4768,6 +4888,7 @@ func TestContainSubstring(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				ContainSubstring(mockT, tt.actual, tt.substring, tt.opts...)
 
@@ -4782,6 +4903,7 @@ func TestContainSubstring(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -4828,6 +4950,7 @@ func TestContainSubstring(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				ContainSubstring(mockT, tt.actual, tt.substring)
 
@@ -4845,6 +4968,7 @@ func TestContainSubstring(t *testing.T) {
 	})
 
 	t.Run("Long string handling", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name       string
 			actual     string
@@ -4853,8 +4977,10 @@ func TestContainSubstring(t *testing.T) {
 			errorCheck func(t *testing.T, message string)
 		}{
 			{
-				name:       "should use multiline formatting for long strings",
-				actual:     "This is a very long string that exceeds the 200 character limit and should trigger multiline formatting in the error message to provide better readability for developers debugging their tests when the assertion fails",
+				name: "should use multiline formatting for long strings",
+				actual: "This is a very long string that exceeds the 200 character limit and should trigger " +
+					"multiline formatting in the error message to provide better readability for developers " +
+					"debugging their tests when the assertion fails",
 				substring:  "nonexistent",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
@@ -4900,6 +5026,7 @@ func TestContainSubstring(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				ContainSubstring(mockT, tt.actual, tt.substring)
 
@@ -4923,6 +5050,7 @@ func TestFail(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name           string
 			message        string
@@ -4962,6 +5090,7 @@ func TestFail(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				fail(mockT, tt.message, tt.args...)
 
@@ -4977,6 +5106,7 @@ func TestFail(t *testing.T) {
 	})
 
 	t.Run("Security - Percent character handling", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name           string
 			message        string
@@ -5016,6 +5146,7 @@ func TestFail(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				fail(mockT, tt.message, tt.args...)
 
@@ -5031,6 +5162,7 @@ func TestFail(t *testing.T) {
 	})
 
 	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name           string
 			message        string
@@ -5070,6 +5202,7 @@ func TestFail(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				fail(mockT, tt.message, tt.args...)
 
@@ -5085,6 +5218,7 @@ func TestFail(t *testing.T) {
 	})
 
 	t.Run("Format string validation", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			name        string
 			message     string
@@ -5117,6 +5251,7 @@ func TestFail(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 
 				defer func() {
@@ -5140,8 +5275,10 @@ func TestFail(t *testing.T) {
 
 	t.Run("Helper method call", func(t *testing.T) {
 		// This test verifies that fail calls t.Helper()
+		t.Parallel()
 
 		t.Run("should call Helper method", func(t *testing.T) {
+			t.Parallel()
 			mockT := &mockT{}
 
 			fail(mockT, "test message")
@@ -5157,6 +5294,7 @@ func TestFail_Integration(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Integration with BeTrue", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		BeTrue(mockT, false)
 
@@ -5171,6 +5309,7 @@ func TestFail_Integration(t *testing.T) {
 	})
 
 	t.Run("Integration with custom message", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		BeTrue(mockT, false, WithMessage("custom error"))
 
@@ -5187,6 +5326,7 @@ func TestFail_Integration(t *testing.T) {
 	})
 
 	t.Run("Integration with percent characters in custom message", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockT{}
 		BeTrue(mockT, false, WithMessage("progress: 100% complete"))
 
@@ -5241,6 +5381,7 @@ func TestBeInRange(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				BeInRange(mockT, tt.value, tt.minValue, tt.maxValue, tt.opts...)
 
@@ -5289,6 +5430,7 @@ func TestBeInRange(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 				mockT := &mockT{}
 				BeInRange(mockT, tt.value, tt.minValue, tt.maxValue)
 
@@ -5340,6 +5482,7 @@ func TestBeInRange(t *testing.T) {
 }
 
 func TestBeSorted(t *testing.T) {
+	t.Parallel()
 	// Helper function to reduce repetition
 	runSortTest := func(collection any, shouldFail bool, msgCheck string) {
 		mockTest := &mockT{}

--- a/assert/assetions_test.go
+++ b/assert/assetions_test.go
@@ -5343,7 +5343,23 @@ func TestBeSorted(t *testing.T) {
 	// Helper function to reduce repetition
 	runSortTest := func(collection any, shouldFail bool, msgCheck string) {
 		mockTest := &mockT{}
-		BeSorted(mockTest, collection)
+
+		switch elements := collection.(type) {
+		case []int:
+			BeSorted(mockTest, elements)
+		case [5]int:
+			BeSorted(mockTest, elements[:]) // Convert array to slice
+		case [3]int:
+			BeSorted(mockTest, elements[:]) // Convert array to slice
+		case []float64:
+			BeSorted(mockTest, elements)
+		case []string:
+			BeSorted(mockTest, elements)
+		case [3]string:
+			BeSorted(mockTest, elements[:]) // Convert array to slice
+		default:
+			t.Fatalf("Unsupported type in test: %T", collection)
+		}
 
 		if shouldFail && !mockTest.Failed() {
 			t.Error("Expected failure but test passed")
@@ -5393,23 +5409,6 @@ func TestBeSorted(t *testing.T) {
 		runSortTest([]float64{1.0, 1.1, 1.2}, false, "")        // float precision
 	})
 
-	t.Run("Error cases", func(t *testing.T) {
-		t.Parallel()
-
-		nonCollectionMock := &mockT{}
-		BeSorted(nonCollectionMock, 42) // not slice/array
-		if !nonCollectionMock.Failed() || !strings.Contains(nonCollectionMock.message, "slices or arrays") {
-			t.Errorf("Expected error for non-slice/array type")
-		}
-
-		unsortableTypeMock := &mockT{}
-		type unsortable struct{ value int }
-		BeSorted(unsortableTypeMock, []unsortable{{1}, {2}}) // unsortable elements
-		if !unsortableTypeMock.Failed() || !strings.Contains(unsortableTypeMock.message, "sortable types") {
-			t.Errorf("Expected error for unsortable element type")
-		}
-	})
-
 	t.Run("Large collection", func(t *testing.T) {
 		t.Parallel()
 
@@ -5431,6 +5430,7 @@ func TestBeSorted(t *testing.T) {
 			t.Errorf("Expected custom message in error")
 		}
 	})
+
 }
 
 // generateUnsortedLargeSlice creates a large slice with some violations for testing

--- a/assert/types.go
+++ b/assert/types.go
@@ -13,6 +13,9 @@ type Config struct {
 	Message    string
 	IgnoreCase bool
 	StackTrace bool
+	// Time comparison options
+	IgnoreTimezone    bool
+	IgnoreNanoseconds bool
 	/*
 		 	Description    string
 			DeepComparison bool
@@ -28,6 +31,12 @@ type ignoreCase bool
 // stackTrace is a boolean flag for including stack traces on NotPanic assertions.
 type stackTrace bool
 
+// ignoreTimezone configures time comparisons to ignore timezone/location differences
+type ignoreTimezone bool
+
+// ignoreNanoseconds configures time comparisons to ignore sub-second differences
+type ignoreNanoseconds bool
+
 // Apply sets the custom message in the config.
 func (m message) Apply(c *Config) {
 	c.Message = string(m)
@@ -39,6 +48,16 @@ func (i ignoreCase) Apply(c *Config) {
 
 func (s stackTrace) Apply(c *Config) {
 	c.StackTrace = bool(s)
+}
+
+// Apply implements Option for ignoreTimezone
+func (i ignoreTimezone) Apply(c *Config) {
+	c.IgnoreTimezone = bool(i)
+}
+
+// Apply implements Option for ignoreNanoseconds
+func (i ignoreNanoseconds) Apply(c *Config) {
+	c.IgnoreNanoseconds = bool(i)
 }
 
 // WithMessage creates an option for setting a custom error message.
@@ -54,6 +73,18 @@ func WithIgnoreCase() Option {
 // WithStackTrace creates an option for including stack traces on NotPanic assertions.
 func WithStackTrace() Option {
 	return stackTrace(true)
+}
+
+// WithIgnoreTimezone creates an option for ignoring timezone when comparing times.
+// When enabled, comparisons use calendar components (year, month, day, hour, minute, second[, ns])
+// and do not consider the Location/offset.
+func WithIgnoreTimezone() Option {
+	return ignoreTimezone(true)
+}
+
+// WithIgnoreNanoseconds creates an option for ignoring sub-second differences when comparing times.
+func WithIgnoreNanoseconds() Option {
+	return ignoreNanoseconds(true)
 }
 
 // fieldDiff represents a single difference between two compared values.

--- a/assert/types.go
+++ b/assert/types.go
@@ -1,5 +1,7 @@
 package assert
 
+import "cmp"
+
 // Option is a functional option for configuring assertions.
 type Option interface {
 	Apply(config *Config)
@@ -114,6 +116,12 @@ type Ordered interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
 		~float32 | ~float64
+}
+
+// Sortable is a type constraint for types that can be sorted.
+// It uses Go's cmp.Ordered constraint for type-safe sorting operations.
+type Sortable interface {
+	cmp.Ordered
 }
 
 // MapContainResult represents the result of checking if a map contains a key or value

--- a/assert/types.go
+++ b/assert/types.go
@@ -132,3 +132,17 @@ type CloseMatch struct {
 	Value       interface{}
 	Differences []string
 }
+
+// sortViolation represents a single violation in sort order
+type sortViolation struct {
+	Index int
+	Value interface{}
+	Next  interface{}
+}
+
+// sortCheckResult contains the result of checking if a collection is sorted
+type sortCheckResult struct {
+	IsSorted   bool
+	Violations []sortViolation
+	Total      int
+}

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -258,7 +258,14 @@ func compareExpectedActual(expected, actual interface{}, path string) (diffs []f
 		for i := 0; i < expectedValue.Len(); i++ {
 			if !reflect.DeepEqual(expectedValue.Index(i).Interface(), actualValue.Index(i).Interface()) {
 				elementPath := buildPath(path, fmt.Sprintf("[%d]", i))
-				diffs = append(diffs, compareExpectedActual(expectedValue.Index(i).Interface(), actualValue.Index(i).Interface(), elementPath)...)
+				diffs = append(
+					diffs,
+					compareExpectedActual(
+						expectedValue.Index(i).Interface(),
+						actualValue.Index(i).Interface(),
+						elementPath,
+					)...,
+				)
 			}
 		}
 
@@ -1089,7 +1096,12 @@ func formatDuplicatesErrors(duplicates []duplicateGroup) string {
 		if len(group.Indexes) > 4 {
 			windowMsg := formatIndexesWindow(group.Indexes, 4)
 
-			msg.WriteString(fmt.Sprintf("\n└─ %s appears %d times at indexes %v", formatDuplicateItem(group.Value), len(group.Indexes), windowMsg))
+			msg.WriteString(fmt.Sprintf(
+				"\n└─ %s appears %d times at indexes %v",
+				formatDuplicateItem(group.Value),
+				len(group.Indexes),
+				windowMsg,
+			))
 			continue
 		}
 
@@ -1598,7 +1610,15 @@ func containsMapValue(mapValue interface{}, targetValue interface{}) MapContainR
 			if len(diffs) > 0 {
 				var diffStrings []string
 				for _, d := range diffs {
-					diffStrings = append(diffStrings, fmt.Sprintf("%s (%v ≠ %v)", d.Path, formatDiffValueConcise(d.Expected), formatDiffValueConcise(d.Actual)))
+					diffStrings = append(
+						diffStrings,
+						fmt.Sprintf(
+							"%s (%v ≠ %v)",
+							d.Path,
+							formatDiffValueConcise(d.Expected),
+							formatDiffValueConcise(d.Actual),
+						),
+					)
 				}
 				closeMatches = append(closeMatches, struct {
 					match CloseMatch

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -369,6 +369,7 @@ func TestFormatComparisonValue_ComplexMapKeys(t *testing.T) {
 }
 
 func TestFindInsertionInfo_Parameterized(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name          string
 		collection    []int
@@ -427,6 +428,7 @@ func TestFindInsertionInfo_Parameterized(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			info, err := findInsertionInfo(tc.collection, tc.target)
 			BeNil(t, err)
 			BeEqual(t, info.found, tc.expectedFound)
@@ -450,6 +452,7 @@ func TestFindInsertionInfo_Parameterized(t *testing.T) {
 }
 
 func TestFormatInsertionContext_WithMessage(t *testing.T) {
+	t.Parallel()
 	collection := []int{2, 3, 5, 1, 0}
 	target := 4
 	info, err := findInsertionInfo(collection, target)
@@ -469,6 +472,7 @@ func TestFormatInsertionContext_BoundaryAndLargeCollections(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Collection with 10 elements (no sorted view)", func(t *testing.T) {
+		t.Parallel()
 		collection := []int{0, 1, 2, 3, 4, 9, 8, 7, 6, 5}
 		info, err := findInsertionInfo(collection, 10)
 		BeNil(t, err)
@@ -479,6 +483,7 @@ func TestFormatInsertionContext_BoundaryAndLargeCollections(t *testing.T) {
 	})
 
 	t.Run("Collection with 12 elements (with sorted view)", func(t *testing.T) {
+		t.Parallel()
 		collection := []int{0, 1, 2, 3, 4, 5, 11, 10, 9, 8, 7, 6}
 		info, err := findInsertionInfo(collection, 100)
 		BeNil(t, err)
@@ -810,6 +815,7 @@ func TestMin3(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := min3(tc.a, tc.b, tc.c)
 			BeEqual(t, result, tc.expected)
 		})
@@ -820,6 +826,7 @@ func TestMinMax(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Min function", func(t *testing.T) {
+		t.Parallel()
 		BeEqual(t, min(5, 3), 3)
 		BeEqual(t, min(3, 5), 3)
 		BeEqual(t, min(5, 5), 5)
@@ -827,6 +834,7 @@ func TestMinMax(t *testing.T) {
 	})
 
 	t.Run("Max function", func(t *testing.T) {
+		t.Parallel()
 		BeEqual(t, max(5, 3), 5)
 		BeEqual(t, max(3, 5), 5)
 		BeEqual(t, max(5, 5), 5)
@@ -838,21 +846,25 @@ func TestIsFloat(t *testing.T) {
 	t.Parallel()
 
 	t.Run("With float32", func(t *testing.T) {
+		t.Parallel()
 		result := isFloat(float32(3.14))
 		BeTrue(t, result)
 	})
 
 	t.Run("With float64", func(t *testing.T) {
+		t.Parallel()
 		result := isFloat(3.14)
 		BeTrue(t, result)
 	})
 
 	t.Run("With int", func(t *testing.T) {
+		t.Parallel()
 		result := isFloat(42)
 		BeFalse(t, result)
 	})
 
 	t.Run("With uint", func(t *testing.T) {
+		t.Parallel()
 		result := isFloat(uint(42))
 		BeFalse(t, result)
 	})
@@ -862,12 +874,14 @@ func TestFormatMultilineString(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Short string", func(t *testing.T) {
+		t.Parallel()
 		input := "Hello, World!"
 		result := formatMultilineString(input)
 		BeEqual(t, result, input)
 	})
 
 	t.Run("Long string", func(t *testing.T) {
+		t.Parallel()
 		// Create a string longer than 280 characters
 		input := strings.Repeat("a", 300)
 		result := formatMultilineString(input)
@@ -885,6 +899,7 @@ func TestFormatMultilineString(t *testing.T) {
 	})
 
 	t.Run("Very long string with last lines", func(t *testing.T) {
+		t.Parallel()
 		// Create a string that will trigger "Last lines" section
 		input := strings.Repeat("a", 56*7) // 7 lines worth
 		result := formatMultilineString(input)
@@ -944,6 +959,7 @@ func TestIsSliceOrArray(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := isSliceOrArray(tc.input)
 			BeEqual(t, result, tc.expected)
 		})
@@ -954,6 +970,7 @@ func TestFormatSlice(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Valid slice", func(t *testing.T) {
+		t.Parallel()
 		input := []int{1, 2, 3}
 		result := formatSlice(input)
 		expected := "[1, 2, 3]"
@@ -961,6 +978,7 @@ func TestFormatSlice(t *testing.T) {
 	})
 
 	t.Run("Non-slice input", func(t *testing.T) {
+		t.Parallel()
 		input := "not a slice"
 		result := formatSlice(input)
 		expected := "<not a slice or array: string>"
@@ -972,6 +990,7 @@ func TestFormatValueComparison_EdgeCases(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Invalid value", func(t *testing.T) {
+		t.Parallel()
 		var v reflect.Value
 		result := formatValueComparison(v)
 		expected := "nil"
@@ -979,6 +998,7 @@ func TestFormatValueComparison_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("Unexported interface", func(t *testing.T) {
+		t.Parallel()
 		// Test case for interface{} that can't be interfaced
 		v := reflect.ValueOf(42)
 		result := formatValueComparison(v)
@@ -1029,6 +1049,7 @@ func TestLevenshteinDistance(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := levenshteinDistance(tc.s1, tc.s2)
 			BeEqual(t, result, tc.expected)
 		})
@@ -1077,6 +1098,7 @@ func TestGenerateTypoDetails(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := generateTypoDetails(tc.target, tc.candidate, tc.distance)
 			BeEqual(t, result, tc.expected)
 		})
@@ -1089,6 +1111,7 @@ func TestFormatEmptyError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Empty string - expecting empty", func(t *testing.T) {
+		t.Parallel()
 		result := formatEmptyError("", true)
 		expectedParts := []string{
 			"Expected value to be empty, but it was not:",
@@ -1104,6 +1127,7 @@ func TestFormatEmptyError(t *testing.T) {
 	})
 
 	t.Run("Non-empty string - expecting not empty", func(t *testing.T) {
+		t.Parallel()
 		result := formatEmptyError("hello", false)
 		expectedParts := []string{
 			"Expected value to be not empty, but it was empty:",
@@ -1119,6 +1143,7 @@ func TestFormatEmptyError(t *testing.T) {
 	})
 
 	t.Run("Large slice - expecting empty", func(t *testing.T) {
+		t.Parallel()
 		largeSlice := make([]int, 10)
 		for i := range largeSlice {
 			largeSlice[i] = i
@@ -1140,6 +1165,7 @@ func TestFormatEmptyError(t *testing.T) {
 	})
 
 	t.Run("Long string - expecting empty", func(t *testing.T) {
+		t.Parallel()
 		longString := strings.Repeat("a", 200)
 		result := formatEmptyError(longString, true)
 
@@ -1166,6 +1192,7 @@ func TestFormatEmptyError(t *testing.T) {
 	})
 
 	t.Run("Map - expecting empty", func(t *testing.T) {
+		t.Parallel()
 		testMap := map[string]int{"a": 1, "b": 2, "c": 3, "d": 4}
 		result := formatEmptyError(testMap, true)
 
@@ -1183,6 +1210,7 @@ func TestFormatEmptyError(t *testing.T) {
 	})
 
 	t.Run("Channel - expecting empty", func(t *testing.T) {
+		t.Parallel()
 		ch := make(chan int)
 		result := formatEmptyError(ch, true)
 
@@ -1200,6 +1228,7 @@ func TestFormatEmptyError(t *testing.T) {
 	})
 
 	t.Run("Other type - expecting empty", func(t *testing.T) {
+		t.Parallel()
 		result := formatEmptyError(42, true)
 
 		expectedParts := []string{
@@ -1220,6 +1249,7 @@ func TestFormatNumericComparisonError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Greater than - positive difference", func(t *testing.T) {
+		t.Parallel()
 		result := formatNumericComparisonError(10, 5, "greater")
 
 		expectedParts := []string{
@@ -1237,6 +1267,7 @@ func TestFormatNumericComparisonError(t *testing.T) {
 	})
 
 	t.Run("Less than - should fail with larger value", func(t *testing.T) {
+		t.Parallel()
 		result := formatNumericComparisonError(8, 3, "less")
 
 		expectedParts := []string{
@@ -1255,6 +1286,7 @@ func TestFormatNumericComparisonError(t *testing.T) {
 	})
 
 	t.Run("Equal values", func(t *testing.T) {
+		t.Parallel()
 		result := formatNumericComparisonError(5, 5, "greater")
 
 		expectedParts := []string{
@@ -1273,6 +1305,7 @@ func TestFormatNumericComparisonError(t *testing.T) {
 	})
 
 	t.Run("GreaterOrEqual operation", func(t *testing.T) {
+		t.Parallel()
 		result := formatNumericComparisonError(3, 5, "greaterOrEqual")
 
 		expectedParts := []string{
@@ -1288,6 +1321,7 @@ func TestFormatNumericComparisonError(t *testing.T) {
 	})
 
 	t.Run("LessOrEqual operation", func(t *testing.T) {
+		t.Parallel()
 		result := formatNumericComparisonError(8, 5, "lessOrEqual")
 
 		expectedParts := []string{
@@ -1840,6 +1874,7 @@ func TestFormatMapContainValueError(t *testing.T) {
 }
 
 func TestFormatComplexType(t *testing.T) {
+	t.Parallel()
 	type SimpleStruct struct {
 		Name string
 		Age  int
@@ -1873,14 +1908,18 @@ func TestFormatComplexType(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := formatComplexType(test.input)
-		if result != test.expected {
-			t.Errorf("formatComplexType(%s): expected %q, got %q", test.name, test.expected, result)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := formatComplexType(test.input)
+			if result != test.expected {
+				t.Errorf("formatComplexType(%s): expected %q, got %q", test.name, test.expected, result)
+			}
+		})
 	}
 }
 
 func TestFormatStructWithTruncation(t *testing.T) {
+	t.Parallel()
 	type LongStruct struct {
 		Field1 string
 		Field2 string
@@ -1910,6 +1949,7 @@ func TestFormatStructWithTruncation(t *testing.T) {
 }
 
 func TestFormatFieldWithTruncation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    interface{}
@@ -1958,15 +1998,19 @@ func TestFormatFieldWithTruncation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v := reflect.ValueOf(test.input)
-		result := formatFieldWithTruncation(v)
-		if result != test.expected {
-			t.Errorf("formatFieldWithTruncation(%s): expected %q, got %q", test.name, test.expected, result)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			v := reflect.ValueOf(test.input)
+			result := formatFieldWithTruncation(v)
+			if result != test.expected {
+				t.Errorf("formatFieldWithTruncation(%s): expected %q, got %q", test.name, test.expected, result)
+			}
+		})
 	}
 }
 
 func TestFormatDiffValueConcise(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    interface{}
@@ -2035,14 +2079,18 @@ func TestFormatDiffValueConcise(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := formatDiffValueConcise(test.input)
-		if result != test.expected {
-			t.Errorf("formatDiffValueConcise(%s): expected %q, got %q", test.name, test.expected, result)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := formatDiffValueConcise(test.input)
+			if result != test.expected {
+				t.Errorf("formatDiffValueConcise(%s): expected %q, got %q", test.name, test.expected, result)
+			}
+		})
 	}
 }
 
 func TestContainsMapValue_CloseMatches(t *testing.T) {
+	t.Parallel()
 	type TestStruct struct {
 		Name string
 		Age  int
@@ -2074,6 +2122,7 @@ func TestContainsMapValue_CloseMatches(t *testing.T) {
 }
 
 func TestContainsMapValue_NonStruct(t *testing.T) {
+	t.Parallel()
 	testMap := map[string]string{
 		"key1": "value1",
 		"key2": "value2",
@@ -2094,6 +2143,7 @@ func TestContainsMapValue_NonStruct(t *testing.T) {
 }
 
 func TestFormatMapContainValueError_ComplexTypes(t *testing.T) {
+	t.Parallel()
 	type TestStruct struct {
 		Name string
 		Age  int
@@ -2128,6 +2178,7 @@ func TestFormatMapContainValueError_ComplexTypes(t *testing.T) {
 }
 
 func TestFormatMapContainValueError_SimpleTypes(t *testing.T) {
+	t.Parallel()
 	result := MapContainResult{
 		Found:   false,
 		Total:   2,
@@ -2147,6 +2198,7 @@ func TestFormatMapContainValueError_SimpleTypes(t *testing.T) {
 }
 
 func TestFormatMapNotContainKeyError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		target   interface{}
@@ -2177,6 +2229,7 @@ Associated Value: "forty-two"`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := formatMapNotContainKeyError(tt.target, tt.mapValue)
 			if result != tt.expected {
 				t.Errorf("Expected:\n%s\n\nGot:\n%s", tt.expected, result)
@@ -2186,6 +2239,7 @@ Associated Value: "forty-two"`,
 }
 
 func TestFormatMapNotContainValueError_SimpleTypes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		target   interface{}
@@ -2216,6 +2270,7 @@ Found At: key "b"`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := formatMapNotContainValueError(tt.target, tt.mapValue)
 			if !strings.Contains(result, tt.contains) {
 				t.Errorf("Expected result to contain:\n%s\n\nGot:\n%s", tt.contains, result)
@@ -2225,6 +2280,7 @@ Found At: key "b"`,
 }
 
 func TestFormatMapNotContainValueError_ComplexTypes(t *testing.T) {
+	t.Parallel()
 	type User struct {
 		ID   int
 		Name string
@@ -2674,11 +2730,22 @@ func TestFormatRangeError(t *testing.T) {
 		actual := -0.1
 		minValue := 0.0
 		maxValue := 1.0
-		expected := fmt.Sprintf(`Expected value to be in range [%v, %v], but it was below:
+		expected := fmt.Sprintf(
+			`Expected value to be in range [%v, %v], but it was below:
         Value    : %v
         Range    : [%v, %v]
         Distance : %v below minimum (%v < %v)
-        Hint     : Value should be >= %v`, minValue, maxValue, actual, minValue, maxValue, minValue-actual, actual, minValue, minValue)
+        Hint     : Value should be >= %v`,
+			minValue,
+			maxValue,
+			actual,
+			minValue,
+			maxValue,
+			minValue-actual,
+			actual,
+			minValue,
+			minValue,
+		)
 		result := formatRangeError(actual, minValue, maxValue)
 		if result != expected {
 			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)
@@ -2690,11 +2757,22 @@ func TestFormatRangeError(t *testing.T) {
 		actual := 1.1
 		minValue := 0.0
 		maxValue := 1.0
-		expected := fmt.Sprintf(`Expected value to be in range [%v, %v], but it was above:
+		expected := fmt.Sprintf(
+			`Expected value to be in range [%v, %v], but it was above:
         Value    : %v
         Range    : [%v, %v]
         Distance : %v above maximum (%v > %v)
-        Hint     : Value should be <= %v`, minValue, maxValue, actual, minValue, maxValue, actual-maxValue, actual, maxValue, maxValue)
+        Hint     : Value should be <= %v`,
+			minValue,
+			maxValue,
+			actual,
+			minValue,
+			maxValue,
+			actual-maxValue,
+			actual,
+			maxValue,
+			maxValue,
+		)
 		result := formatRangeError(actual, minValue, maxValue)
 		if result != expected {
 			t.Errorf("Expected message:\n%s\n\nGot:\n%s", expected, result)

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -3171,3 +3171,424 @@ func TestFormatSortErrorGeneric(t *testing.T) {
 		})
 	})
 }
+
+func TestFormatHaveSameTimeAsError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic error formatting", func(t *testing.T) {
+		t.Parallel()
+		expected := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
+		actual := time.Date(2023, 12, 25, 15, 30, 47, 0, time.UTC)
+		diff := 2 * time.Second
+
+		result := formatHaveSameTimeAsError(expected, actual, diff)
+
+		// Verify main components are present
+		if !strings.Contains(result, "Expected times to have same time") {
+			t.Error("Should contain main error message")
+		}
+		if !strings.Contains(result, "2s") {
+			t.Error("Should contain duration")
+		}
+		if !strings.Contains(result, "later") {
+			t.Error("Should indicate actual is later")
+		}
+		if !strings.Contains(result, "Expected:") {
+			t.Error("Should contain expected time label")
+		}
+		if !strings.Contains(result, "Actual  :") {
+			t.Error("Should contain actual time label")
+		}
+	})
+
+	t.Run("actual earlier than expected", func(t *testing.T) {
+		t.Parallel()
+		expected := time.Date(2023, 12, 25, 15, 30, 47, 0, time.UTC)
+		actual := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
+		diff := 2 * time.Second
+
+		result := formatHaveSameTimeAsError(expected, actual, diff)
+
+		if !strings.Contains(result, "earlier") {
+			t.Error("Should indicate actual is earlier")
+		}
+	})
+
+	t.Run("with fractional seconds", func(t *testing.T) {
+		t.Parallel()
+		expected := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
+		actual := time.Date(2023, 12, 25, 15, 30, 45, 500000000, time.UTC) // +0.5s
+		diff := 500 * time.Millisecond
+
+		result := formatHaveSameTimeAsError(expected, actual, diff)
+
+		if !strings.Contains(result, "500ms") {
+			t.Errorf("Should contain 500ms, got: %s", result)
+		}
+	})
+
+	t.Run("message structure", func(t *testing.T) {
+		t.Parallel()
+		expected := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
+		actual := time.Date(2023, 12, 25, 15, 30, 46, 0, time.UTC)
+		diff := 1 * time.Second
+
+		result := formatHaveSameTimeAsError(expected, actual, diff)
+		lines := strings.Split(result, "\n")
+
+		if len(lines) != 3 {
+			t.Errorf("Expected 3 lines, got %d: %s", len(lines), result)
+		}
+
+		// Check line structure
+		if !strings.HasPrefix(lines[0], "Expected times to have same time") {
+			t.Errorf("First line should start with main message, got: %s", lines[0])
+		}
+		if !strings.HasPrefix(lines[1], "Expected:") {
+			t.Errorf("Second line should start with 'Expected:', got: %s", lines[1])
+		}
+		if !strings.HasPrefix(lines[2], "Actual  :") {
+			t.Errorf("Third line should start with 'Actual  :', got: %s", lines[2])
+		}
+	})
+}
+
+func TestHumanizeDurationSeconds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		// Nanoseconds and microseconds (shown as fractional ms)
+		{
+			name:     "1 nanosecond",
+			duration: 1 * time.Nanosecond,
+			expected: "0.000ms",
+		},
+		{
+			name:     "100 nanoseconds",
+			duration: 100 * time.Nanosecond,
+			expected: "0.000ms",
+		},
+		{
+			name:     "1 microsecond",
+			duration: 1 * time.Microsecond,
+			expected: "0.001ms",
+		},
+		{
+			name:     "500 microseconds",
+			duration: 500 * time.Microsecond,
+			expected: "0.500ms",
+		},
+		{
+			name:     "999 microseconds",
+			duration: 999 * time.Microsecond,
+			expected: "0.999ms",
+		},
+
+		// Milliseconds
+		{
+			name:     "1 millisecond",
+			duration: 1 * time.Millisecond,
+			expected: "1ms",
+		},
+		{
+			name:     "1.5 milliseconds",
+			duration: 1500 * time.Microsecond,
+			expected: "1.5ms",
+		},
+		{
+			name:     "10 milliseconds",
+			duration: 10 * time.Millisecond,
+			expected: "10ms",
+		},
+		{
+			name:     "100 milliseconds",
+			duration: 100 * time.Millisecond,
+			expected: "100ms",
+		},
+		{
+			name:     "999 milliseconds",
+			duration: 999 * time.Millisecond,
+			expected: "999ms",
+		},
+		{
+			name:     "999.9 milliseconds",
+			duration: 999900 * time.Microsecond,
+			expected: "999.9ms",
+		},
+
+		// Seconds
+		{
+			name:     "1 second",
+			duration: 1 * time.Second,
+			expected: "1s",
+		},
+		{
+			name:     "1.5 seconds",
+			duration: 1500 * time.Millisecond,
+			expected: "1.5s",
+		},
+		{
+			name:     "2 seconds",
+			duration: 2 * time.Second,
+			expected: "2s",
+		},
+		{
+			name:     "10 seconds",
+			duration: 10 * time.Second,
+			expected: "10s",
+		},
+		{
+			name:     "30.7 seconds",
+			duration: 30700 * time.Millisecond,
+			expected: "30.7s",
+		},
+		{
+			name:     "60 seconds",
+			duration: 60 * time.Second,
+			expected: "60s",
+		},
+		{
+			name:     "125.3 seconds",
+			duration: 125300 * time.Millisecond,
+			expected: "125.3s",
+		},
+
+		// Large durations
+		{
+			name:     "1 minute",
+			duration: 1 * time.Minute,
+			expected: "60s",
+		},
+		{
+			name:     "1 hour",
+			duration: 1 * time.Hour,
+			expected: "3600s",
+		},
+		{
+			name:     "1 day",
+			duration: 24 * time.Hour,
+			expected: "86400s",
+		},
+
+		// Negative durations (should be handled as positive)
+		{
+			name:     "negative 1 second",
+			duration: -1 * time.Second,
+			expected: "1s",
+		},
+		{
+			name:     "negative 500ms",
+			duration: -500 * time.Millisecond,
+			expected: "500ms",
+		},
+
+		// Edge cases
+		{
+			name:     "zero duration",
+			duration: 0,
+			expected: "0.000ms",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := humanizeDurationSeconds(tt.duration)
+			if result != tt.expected {
+				t.Errorf("humanizeDurationSeconds(%v) = %q, expected %q", tt.duration, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatTimeForDisplay(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UTC times", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			time     time.Time
+			expected string
+		}{
+			{
+				name:     "basic UTC time without nanoseconds",
+				time:     time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC),
+				expected: "2023-12-25 15:30:45 UTC",
+			},
+			{
+				name:     "UTC time with nanoseconds",
+				time:     time.Date(2023, 12, 25, 15, 30, 45, 123456789, time.UTC),
+				expected: "2023-12-25 15:30:45.123456789 UTC",
+			},
+			{
+				name:     "UTC time with trailing zeros in nanoseconds",
+				time:     time.Date(2023, 12, 25, 15, 30, 45, 123000000, time.UTC),
+				expected: "2023-12-25 15:30:45.123 UTC",
+			},
+			{
+				name:     "UTC time with only microseconds",
+				time:     time.Date(2023, 12, 25, 15, 30, 45, 123456000, time.UTC),
+				expected: "2023-12-25 15:30:45.123456 UTC",
+			},
+			{
+				name:     "UTC time with only milliseconds",
+				time:     time.Date(2023, 12, 25, 15, 30, 45, 123000000, time.UTC),
+				expected: "2023-12-25 15:30:45.123 UTC",
+			},
+			{
+				name:     "UTC time with 1 nanosecond",
+				time:     time.Date(2023, 12, 25, 15, 30, 45, 1, time.UTC),
+				expected: "2023-12-25 15:30:45.000000001 UTC",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := formatTimeForDisplay(tt.time)
+				if result != tt.expected {
+					t.Errorf("formatTimeForDisplay(%v) = %q, expected %q", tt.time, result, tt.expected)
+				}
+			})
+		}
+	})
+
+	t.Run("timezone handling", func(t *testing.T) {
+		t.Run("fixed timezone", func(t *testing.T) {
+			t.Parallel()
+			est := time.FixedZone("EST", -5*3600)
+			testTime := time.Date(2023, 12, 25, 10, 30, 45, 0, est)
+
+			result := formatTimeForDisplay(testTime)
+			// Shows UTC time but preserves timezone name
+			expected := "2023-12-25 15:30:45 EST"
+
+			if result != expected {
+				t.Errorf("formatTimeForDisplay(%v) = %q, expected %q", testTime, result, expected)
+			}
+		})
+
+		t.Run("named timezone", func(t *testing.T) {
+			t.Parallel()
+			// Try to load a named timezone
+			loc, err := time.LoadLocation("America/New_York")
+			if err != nil {
+				t.Skip("Could not load timezone data")
+			}
+
+			testTime := time.Date(2023, 6, 15, 14, 30, 45, 0, loc)
+			result := formatTimeForDisplay(testTime)
+
+			// Should show UTC time but preserve timezone name
+			if !strings.Contains(result, "America/New_York") {
+				t.Errorf("Should preserve timezone name, got: %s", result)
+			}
+			if !strings.HasPrefix(result, "2023-06-15 18:30:45") {
+				t.Errorf("Should show UTC time, got: %s", result)
+			}
+		})
+	})
+
+	t.Run("edge cases", func(t *testing.T) {
+		t.Run("zero time", func(t *testing.T) {
+			t.Parallel()
+			result := formatTimeForDisplay(time.Time{})
+			expected := "0001-01-01 00:00:00 UTC"
+
+			if result != expected {
+				t.Errorf("formatTimeForDisplay(zero) = %q, expected %q", result, expected)
+			}
+		})
+
+		t.Run("maximum precision nanoseconds", func(t *testing.T) {
+			t.Parallel()
+			testTime := time.Date(2023, 12, 25, 15, 30, 45, 999999999, time.UTC)
+			result := formatTimeForDisplay(testTime)
+			expected := "2023-12-25 15:30:45.999999999 UTC"
+
+			if result != expected {
+				t.Errorf("formatTimeForDisplay(%v) = %q, expected %q", testTime, result, expected)
+			}
+		})
+
+		t.Run("leap year date", func(t *testing.T) {
+			t.Parallel()
+			testTime := time.Date(2020, 2, 29, 12, 0, 0, 0, time.UTC)
+			result := formatTimeForDisplay(testTime)
+			expected := "2020-02-29 12:00:00 UTC"
+
+			if result != expected {
+				t.Errorf("formatTimeForDisplay(%v) = %q, expected %q", testTime, result, expected)
+			}
+		})
+	})
+}
+
+func TestFormatterIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full error message integration", func(t *testing.T) {
+		t.Parallel()
+		expected := time.Date(2023, 12, 25, 15, 30, 45, 123456789, time.UTC)
+		actual := time.Date(2023, 12, 25, 15, 30, 47, 987654321, time.UTC)
+		diff := actual.Sub(expected)
+
+		result := formatHaveSameTimeAsError(expected, actual, diff)
+
+		lines := strings.Split(result, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("Expected 3 lines, got %d", len(lines))
+		}
+
+		if !strings.Contains(lines[0], "s") {
+			t.Error("Duration should be humanized in first line")
+		}
+
+		if !strings.Contains(lines[1], ".123456789") {
+			t.Error("Expected time should show nanoseconds")
+		}
+		if !strings.Contains(lines[2], ".987654321") {
+			t.Error("Actual time should show nanoseconds")
+		}
+
+		// Check relation
+		if !strings.Contains(lines[2], "later") {
+			t.Error("Should indicate actual is later")
+		}
+	})
+
+	t.Run("different timezone integration", func(t *testing.T) {
+		t.Parallel()
+		utc := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
+		est := time.Date(2023, 12, 25, 10, 30, 46, 0, time.FixedZone("EST", -5*3600))
+		diff := est.Sub(utc)
+
+		result := formatHaveSameTimeAsError(utc, est, diff)
+
+		// Both times should be displayed in UTC format
+		if !strings.Contains(result, "2023-12-25 15:30:45 UTC") {
+			t.Error("Expected time should be in UTC format")
+		}
+		if !strings.Contains(result, "2023-12-25 15:30:46 EST") {
+			t.Error("Actual time should be converted to UTC format")
+		}
+	})
+
+	t.Run("very small difference", func(t *testing.T) {
+		t.Parallel()
+		base := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
+		withNanos := time.Date(2023, 12, 25, 15, 30, 45, 500, time.UTC) // 500ns
+		diff := withNanos.Sub(base)
+
+		result := formatHaveSameTimeAsError(base, withNanos, diff)
+
+		// Should show fractional milliseconds for tiny differences
+		if !strings.Contains(result, "ms") {
+			t.Error("Very small differences should be shown in milliseconds")
+		}
+	})
+}

--- a/should.go
+++ b/should.go
@@ -17,6 +17,7 @@ package should
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Kairum-Labs/should/assert"
 )
@@ -55,6 +56,28 @@ func WithIgnoreCase() Option {
 //	}, should.WithStackTrace())
 func WithStackTrace() Option {
 	return assert.WithStackTrace()
+}
+
+// WithIgnoreTimezone returns an option that makes time comparisons ignore timezone/location differences.
+//
+// Currently, this option is only supported by HaveSameTimeAs.
+//
+// Example:
+//
+//	should.HaveSameTimeAs(t, actual, expected, should.WithIgnoreTimezone())
+func WithIgnoreTimezone() Option {
+	return assert.WithIgnoreTimezone()
+}
+
+// WithIgnoreNanoseconds returns an option that makes time comparisons ignore sub-second differences.
+//
+// Currently, this option is only supported by HaveSameTimeAs.
+//
+// Example:
+//
+//	should.HaveSameTimeAs(t, actual, expected, should.WithIgnoreNanoseconds())
+func WithIgnoreNanoseconds() Option {
+	return assert.WithIgnoreNanoseconds()
 }
 
 // BeTrue reports a test failure if the value is not true.
@@ -490,6 +513,31 @@ func NotPanic(t testing.TB, fn func(), opts ...Option) {
 func HaveLength(t testing.TB, actual any, expected int, opts ...Option) {
 	t.Helper()
 	assert.HaveLength(t, actual, expected, opts...)
+}
+
+// HaveSameTimeAs reports a test failure if two `time.Time` values do not represent the same time.
+//
+// By default, the comparison is timezone-sensitive and nanosecond-precise. You can customize
+// the behavior with functional options:
+//
+// - should.WithIgnoreTimezone(): compares the instants regardless of the timezone/location
+//
+// - should.WithIgnoreNanoseconds(): ignores sub-second differences
+//
+// Example:
+//
+//	should.HaveSameTimeAs(t, time1, time2)
+//
+//	should.HaveSameTimeAs(
+//	    t,
+//	    actual,
+//	    expected,
+//	    should.WithIgnoreTimezone(),
+//	    should.WithIgnoreNanoseconds(),
+//	)
+func HaveSameTimeAs(t testing.TB, actual time.Time, expected time.Time, opts ...Option) {
+	t.Helper()
+	assert.HaveSameTimeAs(t, actual, expected, opts...)
 }
 
 // BeOfType reports a test failure if the value is not of the expected type.

--- a/should.go
+++ b/should.go
@@ -263,6 +263,29 @@ func BeInRange[T assert.Ordered](t testing.TB, actual T, minValue T, maxValue T,
 	assert.BeInRange(t, actual, minValue, maxValue, opts...)
 }
 
+// BeSorted reports a test failure if the slice or array is not sorted in ascending order.
+//
+// This assertion checks if all elements in the slice or array are in ascending order.
+// It provides detailed error messages showing order violations, including the index
+// and values that are out of order. For large collections, it shows a summary with
+// the total number of violations and displays up to 5 specific violations.
+//
+// Example:
+//
+//	should.BeSorted(t, []int{1, 2, 3, 4, 5})
+//
+//	should.BeSorted(t, [5]int{1, 2, 3, 4, 5})
+//
+//	should.BeSorted(t, []float64{1.1, 2.2, 3.3}, should.WithMessage("Values must be in order"))
+//
+//	should.BeSorted(t, []string{"apple", "banana", "cherry"})
+//
+// Works with slices and arrays of sortable types (numeric types and strings)
+func BeSorted(t testing.TB, actual any, opts ...Option) {
+	t.Helper()
+	assert.BeSorted(t, actual, opts...)
+}
+
 // BeEqual reports a test failure if the two values are not deeply equal.
 //
 // This assertion uses Go's reflect.DeepEqual for comparison and provides detailed

--- a/should.go
+++ b/should.go
@@ -263,25 +263,22 @@ func BeInRange[T assert.Ordered](t testing.TB, actual T, minValue T, maxValue T,
 	assert.BeInRange(t, actual, minValue, maxValue, opts...)
 }
 
-// BeSorted reports a test failure if the slice or array is not sorted in ascending order.
+// BeSorted reports a test failure if the slice is not sorted in ascending order.
 //
-// This assertion checks if all elements in the slice or array are in ascending order.
-// It provides detailed error messages showing order violations, including the index
-// and values that are out of order. For large collections, it shows a summary with
-// the total number of violations and displays up to 5 specific violations.
+// This assertion works with slices of any ordered type (integers, floats, strings).
+// For arrays, convert to slice using slice syntax: myArray[:].
+// Provides detailed error messages showing order violations with indices and values.
 //
 // Example:
 //
 //	should.BeSorted(t, []int{1, 2, 3, 4, 5})
 //
-//	should.BeSorted(t, [5]int{1, 2, 3, 4, 5})
+//	should.BeSorted(t, []string{"a", "b", "c"})
 //
-//	should.BeSorted(t, []float64{1.1, 2.2, 3.3}, should.WithMessage("Values must be in order"))
+//	should.BeSorted(t, myArray[:]) // for arrays
 //
-//	should.BeSorted(t, []string{"apple", "banana", "cherry"})
-//
-// Works with slices and arrays of sortable types (numeric types and strings)
-func BeSorted(t testing.TB, actual any, opts ...Option) {
+// Only works with slices of ordered types (cmp.Ordered constraint).
+func BeSorted[T assert.Sortable](t testing.TB, actual []T, opts ...Option) {
 	t.Helper()
 	assert.BeSorted(t, actual, opts...)
 }

--- a/should_test.go
+++ b/should_test.go
@@ -30,7 +30,9 @@ func (m *mockTB) FailNow() {
 }
 
 func TestAssertions(t *testing.T) {
+	t.Parallel()
 	t.Run("BeEqual should pass for equal values", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeEqual(mockT, "some value", "some value")
 		if mockT.failed {
@@ -39,6 +41,7 @@ func TestAssertions(t *testing.T) {
 	})
 
 	t.Run("BeEqual should fail for unequal values", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeEqual(mockT, "some value", "another value")
 		if !mockT.failed {
@@ -48,6 +51,7 @@ func TestAssertions(t *testing.T) {
 }
 
 func TestPanic(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name        string
 		fn          func()
@@ -79,6 +83,7 @@ func TestPanic(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockT := &mockTB{}
 			Panic(mockT, tc.fn, tc.opts...)
 
@@ -94,6 +99,7 @@ func TestPanic(t *testing.T) {
 }
 
 func TestNotPanic(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name        string
 		fn          func()
@@ -125,6 +131,7 @@ func TestNotPanic(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockT := &mockTB{}
 			NotPanic(mockT, tc.fn, tc.opts...)
 
@@ -140,8 +147,10 @@ func TestNotPanic(t *testing.T) {
 }
 
 func TestWrappers(t *testing.T) {
+	t.Parallel()
 	// BeTrue
 	t.Run("BeTrue passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeTrue(mockT, true)
 		if mockT.failed {
@@ -149,6 +158,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeTrue fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeTrue(mockT, false)
 		if !mockT.failed {
@@ -158,6 +168,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeFalse
 	t.Run("BeFalse passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeFalse(mockT, false)
 		if mockT.failed {
@@ -165,6 +176,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeFalse fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeFalse(mockT, true)
 		if !mockT.failed {
@@ -174,6 +186,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeEmpty
 	t.Run("BeEmpty passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeEmpty(mockT, "")
 		if mockT.failed {
@@ -181,6 +194,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeEmpty fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeEmpty(mockT, "not empty")
 		if !mockT.failed {
@@ -190,6 +204,7 @@ func TestWrappers(t *testing.T) {
 
 	// NotBeEmpty
 	t.Run("NotBeEmpty passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotBeEmpty(mockT, "not empty")
 		if mockT.failed {
@@ -197,6 +212,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("NotBeEmpty fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotBeEmpty(mockT, "")
 		if !mockT.failed {
@@ -206,6 +222,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeNil
 	t.Run("BeNil passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeNil(mockT, nil)
 		if mockT.failed {
@@ -213,6 +230,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeNil fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		var x = 1
 		BeNil(mockT, &x)
@@ -223,6 +241,7 @@ func TestWrappers(t *testing.T) {
 
 	// NotBeNil
 	t.Run("NotBeNil passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		var x = 1
 		NotBeNil(mockT, &x)
@@ -231,6 +250,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("NotBeNil fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotBeNil(mockT, nil)
 		if !mockT.failed {
@@ -239,6 +259,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("NotBeEqual passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotBeEqual(mockT, "a", "b")
 		if mockT.failed {
@@ -248,6 +269,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeGreaterThan
 	t.Run("BeGreaterThan passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeGreaterThan(mockT, 10, 5)
 		if mockT.failed {
@@ -255,6 +277,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeGreaterThan fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeGreaterThan(mockT, 5, 10)
 		if !mockT.failed {
@@ -264,6 +287,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeLessThan
 	t.Run("BeLessThan passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeLessThan(mockT, 5, 10)
 		if mockT.failed {
@@ -271,6 +295,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeLessThan fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeLessThan(mockT, 10, 5)
 		if !mockT.failed {
@@ -280,6 +305,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeGreaterOrEqualTo
 	t.Run("BeGreaterOrEqualTo passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeGreaterOrEqualTo(mockT, 10, 10)
 		if mockT.failed {
@@ -287,6 +313,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeGreaterOrEqualTo fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeGreaterOrEqualTo(mockT, 9, 10)
 		if !mockT.failed {
@@ -295,6 +322,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("BeLessOrEqualTo passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeLessOrEqualTo(mockT, 10, 10)
 		if mockT.failed {
@@ -304,6 +332,7 @@ func TestWrappers(t *testing.T) {
 
 	// Contain
 	t.Run("Contain passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		Contain(mockT, []int{1, 2, 3}, 2)
 		if mockT.failed {
@@ -311,6 +340,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("Contain fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		Contain(mockT, []int{1, 2, 3}, 4)
 		if !mockT.failed {
@@ -320,6 +350,7 @@ func TestWrappers(t *testing.T) {
 
 	// NotContain
 	t.Run("NotContain passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotContain(mockT, []int{1, 2, 3}, 4)
 		if mockT.failed {
@@ -328,6 +359,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("NotContain fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotContain(mockT, []int{1, 2, 3}, 2)
 		if !mockT.failed {
@@ -336,6 +368,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("NotContainDuplicates passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotContainDuplicates(mockT, []int{1, 2, 3})
 		if mockT.failed {
@@ -344,6 +377,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("NotContainKey passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotContainKey(mockT, map[string]int{"a": 1, "b": 2}, "c")
 		if mockT.failed {
@@ -352,6 +386,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("NotContainValue passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotContainValue(mockT, map[string]int{"a": 1, "b": 2}, 3)
 		if mockT.failed {
@@ -360,6 +395,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("StartWith passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		StartWith(mockT, "Hello, world!", "Hello")
 		StartWith(mockT, "Hello, world!", "hello", WithIgnoreCase())
@@ -369,6 +405,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("EndWith passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		EndWith(mockT, "Hello, world", "world")
 		if mockT.failed {
@@ -378,6 +415,7 @@ func TestWrappers(t *testing.T) {
 
 	// ContainFunc
 	t.Run("ContainFunc passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		ContainFunc(mockT, []int{1, 2, 3}, func(item any) bool { return item.(int) == 2 })
 		if mockT.failed {
@@ -385,6 +423,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("ContainFunc fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		ContainFunc(mockT, []int{1, 2, 3}, func(item any) bool { return item.(int) == 4 })
 		if !mockT.failed {
@@ -393,6 +432,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("ContainSubstring passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		ContainSubstring(mockT, "Hello, world!", "world")
 		if mockT.failed {
@@ -402,6 +442,7 @@ func TestWrappers(t *testing.T) {
 
 	// HaveLength
 	t.Run("HaveLength passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		HaveLength(mockT, []int{1, 2, 3}, 3)
 		if mockT.failed {
@@ -409,6 +450,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("HaveLength fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		HaveLength(mockT, []int{1, 2, 3}, 4)
 		if !mockT.failed {
@@ -418,6 +460,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeOfType
 	t.Run("BeOfType passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeOfType(mockT, "hello", "world")
 		if mockT.failed {
@@ -425,6 +468,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeOfType fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeOfType(mockT, "hello", 123)
 		if !mockT.failed {
@@ -434,6 +478,7 @@ func TestWrappers(t *testing.T) {
 
 	// BeOneOf
 	t.Run("BeOneOf passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeOneOf(mockT, "a", []string{"a", "b"})
 		if mockT.failed {
@@ -441,6 +486,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeOneOf fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeOneOf(mockT, "c", []string{"a", "b"})
 		if !mockT.failed {
@@ -449,6 +495,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("BeSorted passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeSorted(mockT, []int{1, 2, 3})
 		if mockT.failed {
@@ -457,6 +504,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("BeInRange passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeInRange(mockT, 5, 0, 10)
 		if mockT.failed {
@@ -464,6 +512,7 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 	t.Run("BeInRange fails", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		BeInRange(mockT, 15, 0, 10)
 		if !mockT.failed {
@@ -472,6 +521,7 @@ func TestWrappers(t *testing.T) {
 	})
 
 	t.Run("NotPanic with stack trace passes", func(t *testing.T) {
+		t.Parallel()
 		mockT := &mockTB{}
 		NotPanic(mockT, func() {
 		}, WithStackTrace())

--- a/should_test.go
+++ b/should_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 type mockTB struct {
@@ -455,6 +456,15 @@ func TestWrappers(t *testing.T) {
 		HaveLength(mockT, []int{1, 2, 3}, 4)
 		if !mockT.failed {
 			t.Error("HaveLength should fail")
+		}
+	})
+
+	t.Run("HaveSameTimeAs passes", func(t *testing.T) {
+		t.Parallel()
+		mockT := &mockTB{}
+		HaveSameTimeAs(mockT, time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC), time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC))
+		if mockT.failed {
+			t.Error("HaveSameTimeAs should pass")
 		}
 	})
 

--- a/should_test.go
+++ b/should_test.go
@@ -448,7 +448,14 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 
-	// BeInRange
+	t.Run("BeSorted passes", func(t *testing.T) {
+		mockT := &mockTB{}
+		BeSorted(mockT, []int{1, 2, 3})
+		if mockT.failed {
+			t.Error("BeSorted should pass")
+		}
+	})
+
 	t.Run("BeInRange passes", func(t *testing.T) {
 		mockT := &mockTB{}
 		BeInRange(mockT, 5, 0, 10)


### PR DESCRIPTION
* Implemented HaveSameTimeAs function to compare time.Time values with options to ignore timezone and nanoseconds.

Feature requested in feedback