### PR TITLE
fix: remove actual value from BeOfType error output (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ should.BeOfType(t, Cat{Name: "Whiskers"}, d)
 // Expected Type: should_test.Dog
 // Actual Type  : should_test.Cat
 // Difference   : Different concrete types
-// Value        : {Name: "Whiskers"}
 ```
 
 ### String Similarity Detection

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1194,7 +1194,7 @@ func BeOfType(t testing.TB, actual, expected any, opts ...Option) {
 
 	if actualType != expectedType {
 		cfg := processOptions(opts...)
-		errorMsg := formatTypeError(actual, expectedType, actualType)
+		errorMsg := formatTypeError(expectedType, actualType)
 		if cfg.Message != "" {
 			fail(t, "%s\n%s", cfg.Message, errorMsg)
 			return

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3677,8 +3677,7 @@ func TestBeOfType(t *testing.T) {
 		if !strings.Contains(mockT.message, "Expected value to be of specific type:") ||
 			!strings.Contains(mockT.message, "Expected Type: *assert.Dog") ||
 			!strings.Contains(mockT.message, "Actual Type  : *assert.Cat") ||
-			!strings.Contains(mockT.message, "Difference   : Different concrete types") ||
-			!strings.Contains(mockT.message, `Value        : {Name: "Whiskers"}`) {
+			!strings.Contains(mockT.message, "Difference   : Different concrete types") {
 			t.Errorf("Error message format is incorrect.\nGot:\n%s", mockT.message)
 		}
 	})

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -973,19 +973,12 @@ func formatLengthError(actual any, expected, actualLen int) string {
 }
 
 // formatTypeError formats a detailed error message for BeOfType assertions.
-func formatTypeError(actual any, expectedType, actualType reflect.Type) string {
+func formatTypeError(expectedType, actualType reflect.Type) string {
 	var msg strings.Builder
 	msg.WriteString("Expected value to be of specific type:\n")
 	msg.WriteString(fmt.Sprintf("Expected Type: %v\n", expectedType))
 	msg.WriteString(fmt.Sprintf("Actual Type  : %v\n", actualType))
 	msg.WriteString("Difference   : Different concrete types\n")
-
-	// Truncate long values for readability
-	formattedValue := formatComparisonValue(actual)
-	if len(formattedValue) > 80 {
-		formattedValue = formattedValue[:77] + "..."
-	}
-	msg.WriteString(fmt.Sprintf("Value        : %s\n", formattedValue))
 
 	return msg.String()
 }


### PR DESCRIPTION
Closes #31

**Removed** the line  `"Value: ..."` from `BeOfType` error output to make messages clearer.
