### PR TITLE
refactor: update ContainFunc to use type-specific predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ should.NotContainValue(t, userRoles, 3)
 - `Contain(t, collection, element)` - Check if slice/array contains an element
 - `NotContain(t, collection, element)` - Check if slice/array does not contain an element
 - `NotContainDuplicates(t, collection)` - Check if slice/array contains no duplicate values
-- `ContainFunc(t, collection, predicate)` - Check if any element matches a custom predicate
+- `AnyMatch(t, collection, predicate)` - Check if any element matches a custom predicate
 - `BeSorted(t, slice)` - Check if slice is sorted in ascending order (supports numeric types and strings)
 
 ### Map Operations
@@ -769,20 +769,12 @@ people := []Person{
 }
 
 // Find people over 30
-should.ContainFunc(t, people, func(item any) bool {
-    person, ok := item.(Person)
-    if !ok {
-        return false
-    }
+should.AnyMatch(t, people, func(item Person) bool {
     return person.Age > 30
 })
 
 // With custom error message
-should.ContainFunc(t, people, func(item any) bool {
-	person, ok := item.(Person)
-	if !ok {
-		return false
-	}
+should.AnyMatch(t, people, func(item Person) bool {
 	return person.Age >= 65
 }, should.WithMessage("No elderly users found"))
 ```

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1031,38 +1032,30 @@ func NotContainValue[K comparable, V any](t testing.TB, actual map[K]V, expected
 	}
 }
 
-// ContainFunc reports a test failure if no element in the slice or array matches the predicate function.
+// AnyMatch reports a test failure if no element in the slice matches the predicate function.
 //
-// This assertion allows for custom matching logic by providing a predicate function
-// that will be called for each element in the collection. The test passes if any element
+// This assertion allows custom matching logic by providing a predicate function
+// that will be called for each element in the slice. The test passes if any element
 // makes the predicate return true.
 //
 // Example:
 //
-//	should.ContainFunc(t, users, func(item any) bool {
-//		user := item.(User)
+//	type User struct { Age int }
+//
+//	users := []User{{Age: 16}, {Age: 21}}
+//	should.AnyMatch(t, users, func(user User) bool {
 //		return user.Age > 18
 //	})
 //
-//	should.ContainFunc(t, numbers, func(item any) bool {
-//		return item.(int) % 2 == 0
+//	numbers := []int{1, 3, 5, 8}
+//	should.AnyMatch(t, numbers, func(n int) bool {
+//		return n%2 == 0
 //	}, should.WithMessage("No even numbers found"))
-//
-// If the input is not a slice or array, the test fails immediately.
-func ContainFunc[T any](t testing.TB, actual T, expected func(TItem any) bool, opts ...Option) {
+func AnyMatch[T any](t testing.TB, actual []T, predicate func(T) bool, opts ...Option) {
 	t.Helper()
-	if !isSliceOrArray(actual) {
-		fail(t, "expected a slice or array, but got %T", actual)
+
+	if slices.ContainsFunc(actual, predicate) {
 		return
-	}
-
-	actualValue := reflect.ValueOf(actual)
-
-	for i := range actualValue.Len() {
-		item := actualValue.Index(i).Interface()
-		if expected(item) {
-			return
-		}
 	}
 
 	cfg := processOptions(opts...)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -475,12 +475,8 @@ func TestContain_WithCustomMessage(t *testing.T) {
 func TestContainFunc_Succeeds_WhenPredicateMatches(t *testing.T) {
 	t.Parallel()
 
-	ContainFunc(t, []int{1, 2, 3}, func(item any) bool {
-		i, ok := item.(int)
-		if !ok {
-			return false
-		}
-		return i == 2
+	AnyMatch(t, []int{1, 2, 3}, func(item int) bool {
+		return item == 2
 	})
 }
 
@@ -488,7 +484,7 @@ func TestContainFunc_Fails_WhenPredicateDoesNotMatch(t *testing.T) {
 	t.Parallel()
 
 	failed, message := assertFails(t, func(t testing.TB) {
-		ContainFunc(t, []int{1, 2, 3}, func(item any) bool {
+		AnyMatch(t, []int{1, 2, 3}, func(item int) bool {
 			return item == 4
 		})
 	})
@@ -510,14 +506,14 @@ func TestContainFunc_WithCustomMessage(t *testing.T) {
 	customMessage := "No matching element found"
 
 	numbers := []int{1, 3, 5, 7}
-	predicate := func(item any) bool {
-		return item.(int)%2 == 0 // Looking for even numbers
+	predicate := func(item int) bool {
+		return item%2 == 0 // Looking for even numbers
 	}
 
-	ContainFunc(mockT, numbers, predicate, WithMessage(customMessage))
+	AnyMatch(mockT, numbers, predicate, WithMessage(customMessage))
 
 	if !mockT.Failed() {
-		t.Fatal("Expected ContainFunc to fail, but it passed")
+		t.Fatal("Expected AnyMatch to fail, but it passed")
 	}
 
 	if !strings.Contains(mockT.message, customMessage) {
@@ -2228,26 +2224,7 @@ func TestBeFalse_Fails_WithTrueValue(t *testing.T) {
 	}
 }
 
-// === Tests for ContainFunc edge cases ===
-
-func TestContainFunc_Fails_WithNonSliceType(t *testing.T) {
-	t.Parallel()
-
-	failed, message := assertFails(t, func(t testing.TB) {
-		ContainFunc(t, "not a slice", func(item any) bool {
-			return true
-		})
-	})
-
-	if !failed {
-		t.Fatal("Expected test to fail, but it passed")
-	}
-
-	expected := "expected a slice or array, but got string"
-	if !strings.Contains(message, expected) {
-		t.Errorf("Expected message to contain: %q\n\nFull message:\n%s", expected, message)
-	}
-}
+// === Tests for AnyMatch edge cases ===
 
 func TestContainFunc_WithComplexPredicate(t *testing.T) {
 	t.Parallel()
@@ -2264,15 +2241,13 @@ func TestContainFunc_WithComplexPredicate(t *testing.T) {
 	}
 
 	// Should succeed - finding adult user
-	ContainFunc(t, users, func(item any) bool {
-		user := item.(User)
+	AnyMatch(t, users, func(user User) bool {
 		return user.Age >= 18
 	})
 
 	// Should fail - no elderly users
 	failed, message := assertFails(t, func(t testing.TB) {
-		ContainFunc(t, users, func(item any) bool {
-			user := item.(User)
+		AnyMatch(t, users, func(user User) bool {
 			return user.Age >= 65
 		})
 	})

--- a/should.go
+++ b/should.go
@@ -441,27 +441,28 @@ func NotContain(t testing.TB, actual any, expected any, opts ...Option) {
 	assert.NotContain(t, actual, expected, opts...)
 }
 
-// ContainFunc reports a test failure if no element in the slice or array matches the predicate function.
+// AnyMatch reports a test failure if no element in the slice matches the predicate function.
 //
-// This assertion allows for custom matching logic by providing a predicate function
-// that will be called for each element in the collection. The test passes if any element
+// This assertion allows custom matching logic by providing a predicate function
+// that will be called for each element in the slice. The test passes if any element
 // makes the predicate return true.
 //
 // Example:
 //
-//	should.ContainFunc(t, users, func(item any) bool {
-//		user := item.(User)
+//	type User struct { Age int }
+//
+//	users := []User{{Age: 16}, {Age: 21}}
+//	should.AnyMatch(t, users, func(user User) bool {
 //		return user.Age > 18
 //	})
 //
-//	should.ContainFunc(t, numbers, func(item any) bool {
-//		return item.(int) % 2 == 0
+//	numbers := []int{1, 3, 5, 8}
+//	should.AnyMatch(t, numbers, func(n int) bool {
+//		return n%2 == 0
 //	}, should.WithMessage("No even numbers found"))
-//
-// If the input is not a slice or array, the test fails immediately.
-func ContainFunc[T any](t testing.TB, actual T, predicate func(item any) bool, opts ...Option) {
+func AnyMatch[T any](t testing.TB, actual []T, predicate func(T) bool, opts ...Option) {
 	t.Helper()
-	assert.ContainFunc(t, actual, predicate, opts...)
+	assert.AnyMatch(t, actual, predicate, opts...)
 }
 
 // StartWith reports a test failure if the string does not start with the expected substring.

--- a/should_test.go
+++ b/should_test.go
@@ -455,21 +455,21 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 
-	// ContainFunc
-	t.Run("ContainFunc passes", func(t *testing.T) {
+	// AnyMatch
+	t.Run("AnyMatch passes", func(t *testing.T) {
 		t.Parallel()
 		mockT := &mockTB{}
-		ContainFunc(mockT, []int{1, 2, 3}, func(item any) bool { return item.(int) == 2 })
+		AnyMatch(mockT, []int{1, 2, 3}, func(item int) bool { return item == 2 })
 		if mockT.failed {
-			t.Error("ContainFunc should pass")
+			t.Error("AnyMatch should pass")
 		}
 	})
-	t.Run("ContainFunc fails", func(t *testing.T) {
+	t.Run("AnyMatch fails", func(t *testing.T) {
 		t.Parallel()
 		mockT := &mockTB{}
-		ContainFunc(mockT, []int{1, 2, 3}, func(item any) bool { return item.(int) == 4 })
+		AnyMatch(mockT, []int{1, 2, 3}, func(item int) bool { return item == 4 })
 		if !mockT.failed {
-			t.Error("ContainFunc should fail")
+			t.Error("AnyMatch should fail")
 		}
 	})
 


### PR DESCRIPTION
* Changed the ContainFunc signature to accept a slice of type T and a predicate function that takes an item of type T.
* Renamed the ContainFunc assertion to AnyMatch for clarity and consistency.