### PR TITLE
docs: fix formatting of NotBeError example in web docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Handle error check with clear, informative messages:
 ```go
 // Basic usage
 should.BeError(t, err)
+should.NotBeError(t, err)
 
 // Check specific error types
 var pathErr *os.PathError
@@ -449,13 +450,18 @@ should.BeErrorIs(t, err, io.EOF)
 
 // With custom messages
 should.BeError(t, err, should.WithMessage("Expected operation to fail"))
+should.NotBeError(t, err, should.WithMessage("Expected operation to pass"))
 should.BeErrorAs(t, err, &pathErr, should.WithMessage("Expected path error"))
 should.BeErrorIs(t, err, context.Canceled, should.WithMessage("Expected cancellation"))
 
 // Outputs
-// BeError - when no error expected one
+// BeError - error required
 should.BeError(t, err)
 // Expected an error, but got nil
+
+// NotBeError - no error
+should.NotBeError(t, err)
+// Expected nil, but got an error
 
 // BeErrorAs - type not found
 var pathErr *os.PathError

--- a/README.md
+++ b/README.md
@@ -432,6 +432,45 @@ should.NotContainDuplicates(t, []int{1, 2, 2, 3, 3, 3})
 // └─ 3 appears 3 times at indexes [3, 4, 5]
 ```
 
+### Error Assertions
+
+Handle error check with clear, informative messages:
+
+```go
+// Basic usage
+should.BeError(t, err)
+
+// Check specific error types
+var pathErr *os.PathError
+should.BeErrorAs(t, err, &pathErr)
+
+// Check specific error values
+should.BeErrorIs(t, err, io.EOF)
+
+// With custom messages
+should.BeError(t, err, should.WithMessage("Expected operation to fail"))
+should.BeErrorAs(t, err, &pathErr, should.WithMessage("Expected path error"))
+should.BeErrorIs(t, err, context.Canceled, should.WithMessage("Expected cancellation"))
+
+// Outputs
+// BeError - when no error expected one
+should.BeError(t, err)
+// Expected an error, but got nil
+
+// BeErrorAs - type not found
+var pathErr *os.PathError
+should.BeErrorAs(t, err, &pathErr)
+// Expected error to be *os.PathError, but type not found in error chain
+// Error: "invalid character 'i' looking for beginning of value"
+// Types: [*json.SyntaxError]
+
+// BeErrorIs - value not found
+should.BeErrorIs(t, err, io.EOF)
+// Expected error to be "EOF", but value not found in error chain
+// Error: "connection refused"
+// Types: [*net.OpError, syscall.Errno]
+```
+
 ### Time Assertions
 
 Compare times with flexible options:
@@ -755,3 +794,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -461,7 +461,10 @@ should.BeError(t, err)
 
 // NotBeError - no error
 should.NotBeError(t, err)
-// Expected nil, but got an error
+// Expected no error, but got an error
+// Error: "something went wrong"
+// Type: *errors.errorString
+
 
 // BeErrorAs - type not found
 var pathErr *os.PathError

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -321,10 +321,10 @@ func BeError(t testing.TB, err error, opts ...Option) {
 //
 // Example:
 //
-// should.NotBeError(t, err)
+//	should.NotBeError(t, err)
 //
-// _, err = os.Open("/nonexistent/file.txt")
-// should.NotBeError(t, err, should.WithMessage("File should exist and be readable"))
+// 	_, err = os.Open("/nonexistent/file.txt")
+//	should.NotBeError(t, err, should.WithMessage("File should exist and be readable"))
 func NotBeError(t testing.TB, err error, opts ...Option) {
 	t.Helper()
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -331,11 +331,11 @@ func NotBeError(t testing.TB, err error, opts ...Option) {
 
 	if err != nil {
 		if cfg.Message != "" {
-			fail(t, "%s\n%s", cfg.Message, "Expected no error, but got an error")
+			fail(t, "%s\nExpected nil, but got %T", cfg.Message, err)
 			return
 		}
 
-		fail(t, "Expected no error, but got an error")
+		fail(t, "Expected nil, but got %T", err)
 	}
 }
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -331,12 +331,9 @@ func NotBeError(t testing.TB, err error, opts ...Option) {
 	cfg := processOptions(opts...)
 
 	if err != nil {
-		if cfg.Message != "" {
-			fail(t, "%s\nExpected nil, but got %T", cfg.Message, err)
-			return
-		}
+		errorMsg := formatNotBeErrorMessage(cfg.Message, err)
 
-		fail(t, "Expected nil, but got %T", err)
+		fail(t, errorMsg)
 	}
 }
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -313,6 +313,32 @@ func BeError(t testing.TB, err error, opts ...Option) {
 	}
 }
 
+// NotBeError - no error required
+//
+// Verifies that err is nil, ensuring successful operation.
+// Supports optional custom error messages via Option.
+//
+// Example:
+//
+// should.NotBeError(t, err)
+//
+// _, err = os.Open("/nonexistent/file.txt")
+// should.NotBeError(t, err, should.WithMessage("File should exist and be readable"))
+func NotBeError(t testing.TB, err error, opts ...Option) {
+	t.Helper()
+
+	cfg := processOptions(opts...)
+
+	if err != nil {
+		if cfg.Message != "" {
+			fail(t, "%s\n%s", cfg.Message, "Expected no error, but got an error")
+			return
+		}
+
+		fail(t, "Expected no error, but got an error")
+	}
+}
+
 // BeErrorAs reports a test failure if the provided error does not match
 // the target type using errors.As.
 //

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1912,6 +1912,67 @@ func TestBeError(t *testing.T) {
 	})
 }
 
+func TestNotBeError(t *testing.T) {
+	t.Parallel()
+	t.Run("Basic fuctionality", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			err        error
+			opts       []Option
+			shouldFail bool
+			errorCheck func(t *testing.T, message string)
+		}{
+			{
+				name:       "Nil error - should pass",
+				err:        nil,
+				shouldFail: false,
+			},
+			{
+				name:       "Error present - should fail",
+				err:        errors.New("test error"),
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "Expected no error, but got an error") {
+						t.Errorf("Expected an error message, got %s", message)
+					}
+				},
+			},
+			{
+				name:       "An error with a custom error message",
+				err:        errors.New("test an error with a custom error message"),
+				shouldFail: true,
+				opts:       []Option{WithMessage("Custom error message")},
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "Custom error message") {
+						t.Errorf("Expected custom message, got %s", message)
+					}
+					if !strings.Contains(message, "Expected no error, but got an error") {
+						t.Errorf("Expected default message, got %s", message)
+					}
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				mockT := &mockT{}
+				NotBeError(mockT, tt.err, tt.opts...)
+				if tt.shouldFail && !mockT.failed {
+					t.Fatal("Expected test to fail, but it passed")
+				}
+				if !tt.shouldFail && mockT.failed {
+					t.Errorf("Expected test to pass, but it failed: %s", mockT.message)
+				}
+				if tt.errorCheck != nil && mockT.failed {
+					tt.errorCheck(t, mockT.message)
+				}
+			})
+		}
+	})
+}
+
 func TestBeErrorAs(t *testing.T) {
 	t.Parallel()
 	t.Run("Basic functionality", func(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2023,9 +2023,15 @@ func TestNotBeError(t *testing.T) {
 				err:        errors.New("test error"),
 				shouldFail: true,
 				errorCheck: func(t *testing.T, err error, message string) {
-					expected_err_msg := fmt.Sprintf("Expected nil, but got %T", err)
-					if !strings.Contains(message, expected_err_msg) {
-						t.Errorf("Expected an error message, got %s", message)
+					contains := []string{
+						"Expected no error, but got an error",
+						"Error: \"test error\"",
+						"Type: *errors.errorString",
+					}
+					for _, expected := range contains {
+						if !strings.Contains(message, expected) {
+							t.Errorf("Expected an error message, got %s", message)
+						}
 					}
 				},
 			},
@@ -2038,9 +2044,16 @@ func TestNotBeError(t *testing.T) {
 					if !strings.Contains(message, "Custom error message") {
 						t.Errorf("Expected custom message, got %s", message)
 					}
-					expected_err_msg := fmt.Sprintf("Expected nil, but got %T", err)
-					if !strings.Contains(message, expected_err_msg) {
-						t.Errorf("Expected default message, got %s", message)
+					contains := []string{
+						"Custom error message",
+						"Expected no error, but got an error",
+						"Error: \"test an error with a custom error message\"",
+						"Type: *errors.errorString",
+					}
+					for _, expected := range contains {
+						if !strings.Contains(message, expected) {
+							t.Errorf("Expected: %s, got: %s", expected, message)
+						}
 					}
 				},
 			},

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1921,7 +1921,7 @@ func TestNotBeError(t *testing.T) {
 			err        error
 			opts       []Option
 			shouldFail bool
-			errorCheck func(t *testing.T, message string)
+			errorCheck func(t *testing.T, err error, message string)
 		}{
 			{
 				name:       "Nil error - should pass",
@@ -1932,8 +1932,9 @@ func TestNotBeError(t *testing.T) {
 				name:       "Error present - should fail",
 				err:        errors.New("test error"),
 				shouldFail: true,
-				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "Expected no error, but got an error") {
+				errorCheck: func(t *testing.T, err error, message string) {
+					expected_err_msg := fmt.Sprintf("Expected nil, but got %T", err)
+					if !strings.Contains(message, expected_err_msg) {
 						t.Errorf("Expected an error message, got %s", message)
 					}
 				},
@@ -1943,11 +1944,12 @@ func TestNotBeError(t *testing.T) {
 				err:        errors.New("test an error with a custom error message"),
 				shouldFail: true,
 				opts:       []Option{WithMessage("Custom error message")},
-				errorCheck: func(t *testing.T, message string) {
+				errorCheck: func(t *testing.T, err error, message string) {
 					if !strings.Contains(message, "Custom error message") {
 						t.Errorf("Expected custom message, got %s", message)
 					}
-					if !strings.Contains(message, "Expected no error, but got an error") {
+					expected_err_msg := fmt.Sprintf("Expected nil, but got %T", err)
+					if !strings.Contains(message, expected_err_msg) {
 						t.Errorf("Expected default message, got %s", message)
 					}
 				},
@@ -1966,7 +1968,7 @@ func TestNotBeError(t *testing.T) {
 					t.Errorf("Expected test to pass, but it failed: %s", mockT.message)
 				}
 				if tt.errorCheck != nil && mockT.failed {
-					tt.errorCheck(t, mockT.message)
+					tt.errorCheck(t, tt.err, mockT.message)
 				}
 			})
 		}

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -2433,3 +2433,18 @@ func formatBeErrorMessage(action string, err error, target interface{}) string {
 
 	return msg.String()
 }
+
+func formatNotBeErrorMessage(customMsg string, err error) string {
+	var msg strings.Builder
+
+	if customMsg != "" {
+		msg.WriteString(customMsg)
+		msg.WriteString("\n")
+	}
+
+	msg.WriteString("Expected no error, but got an error\n")
+	msg.WriteString(fmt.Sprintf("Error: \"%s\"\n", err.Error()))
+	msg.WriteString(fmt.Sprintf("Type: %T", err))
+
+	return msg.String()
+}

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -2394,4 +2395,29 @@ func formatTimeForDisplay(t time.Time) string {
 	}
 
 	return fmt.Sprintf("%s%s %s", formattedBase, fractionalPart, timeZoneName)
+}
+
+func formatBeErrorMessage(action string, err error, target interface{}) string {
+	var msg strings.Builder
+
+	var types []string
+	unwrappedErr := err
+	for unwrappedErr != nil {
+		types = append(types, reflect.TypeOf(unwrappedErr).String())
+		unwrappedErr = errors.Unwrap(unwrappedErr)
+	}
+
+	switch action {
+	case "as":
+		msg.WriteString(fmt.Sprintf("Expected error to be %T, but type not found in error chain\n", target))
+	case "is":
+		msg.WriteString(fmt.Sprintf("Expected error to be \"%s\", but not found in error chain\n", target))
+	default:
+		msg.WriteString("Assertion failed with an unknown type of error.\n")
+	}
+
+	msg.WriteString(fmt.Sprintf("Error: \"%s\"\n", err.Error()))
+	msg.WriteString(fmt.Sprintf("Types  : [%s]", strings.Join(types, ", ")))
+
+	return msg.String()
 }

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -2438,13 +2438,12 @@ func formatNotBeErrorMessage(customMsg string, err error) string {
 	var msg strings.Builder
 
 	if customMsg != "" {
-		msg.WriteString(customMsg)
-		msg.WriteString("\n")
+		fmt.Fprintf(&msg, "%s\n", customMsg)
 	}
 
-	msg.WriteString("Expected no error, but got an error\n")
-	msg.WriteString(fmt.Sprintf("Error: \"%s\"\n", err.Error()))
-	msg.WriteString(fmt.Sprintf("Type: %T", err))
+	fmt.Fprintf(&msg, "Expected no error, but got an error\n")
+	fmt.Fprintf(&msg, "Error: \"%s\"\n", err.Error())
+	fmt.Fprintf(&msg, "Type: %T", err)
 
 	return msg.String()
 }

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -3760,3 +3760,51 @@ func TestFormatBeErrorMessage(t *testing.T) {
 		}
 	})
 }
+
+func TestFormatNotBeErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct{
+			name string
+			customMsg string
+			err error
+			contains []string
+		}{
+			{
+				name: "with customMsg",
+				customMsg: "File doesn't exist",
+				err: errors.New("test error"),
+				contains: []string{
+					"File doesn't exist",
+					"Expected no error, but got an error",
+					"Error: \"test error\"",
+					"Type: *errors.errorString",
+				},
+			},
+			{
+				name: "empty customMsg",
+				customMsg: "",
+				err: errors.New("test error"),
+				contains: []string{
+					"Expected no error, but got an error",
+					"Error: \"test error\"",
+					"Type: *errors.errorString",
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := formatNotBeErrorMessage(tt.customMsg, tt.err)
+				for _, expected := range tt.contains {
+					if !strings.Contains(result, expected) {
+						t.Errorf("Expected %q in result: \n%s", expected, result)
+					}
+				}
+			})
+		}
+	})
+}

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -3766,16 +3766,16 @@ func TestFormatNotBeErrorMessage(t *testing.T) {
 
 	t.Run("Basic functionality", func(t *testing.T) {
 		t.Parallel()
-		tests := []struct{
-			name string
+		tests := []struct {
+			name      string
 			customMsg string
-			err error
-			contains []string
+			err       error
+			contains  []string
 		}{
 			{
-				name: "with customMsg",
+				name:      "with customMsg",
 				customMsg: "File doesn't exist",
-				err: errors.New("test error"),
+				err:       errors.New("test error"),
 				contains: []string{
 					"File doesn't exist",
 					"Expected no error, but got an error",
@@ -3784,9 +3784,9 @@ func TestFormatNotBeErrorMessage(t *testing.T) {
 				},
 			},
 			{
-				name: "empty customMsg",
+				name:      "empty customMsg",
 				customMsg: "",
-				err: errors.New("test error"),
+				err:       errors.New("test error"),
 				contains: []string{
 					"Expected no error, but got an error",
 					"Error: \"test error\"",

--- a/should.go
+++ b/should.go
@@ -193,6 +193,55 @@ func NotBeNil(t testing.TB, actual any, opts ...Option) {
 	assert.NotBeNil(t, actual, opts...)
 }
 
+// BeError reports a test failure if the provided error is nil.
+//
+// This assertion is useful to ensure that a function call actually
+// produced an error when one is expected. It provides clear failure
+// messages showing when an error was expected but not returned.
+// It supports optional custom error messages through Option.
+//
+// Example:
+//
+//	should.BeError(t, err)
+//	should.BeError(t, err, should.WithMessage("Expected a validation error"))
+func BeError(t testing.TB, err error, opts ...Option) {
+	t.Helper()
+	assert.BeError(t, err)
+}
+
+// BeErrorAs reports a test failure if the provided error does not match
+// the target type using errors.As.
+//
+// This assertion is useful when you need to verify that an error
+// can be unwrapped into a specific type, such as a custom error struct.
+// It supports optional custom error messages through Option.
+//
+// Example:
+//
+//	var pathErr *os.PathError
+//	should.BeErrorAs(t, err, &pathErr)
+//	should.BeErrorAs(t, err, &MyCustomError{}, should.WithMessage("Expected custom error type"))
+func BeErrorAs(t *testing.T, err error, target interface{}, opts ...Option) {
+	t.Helper()
+	assert.BeErrorAs(t, err, target)
+}
+
+// BeErrorIs reports a test failure if the provided error is not equal to
+// the target error using errors.Is.
+//
+// This assertion is useful to check if an error matches a specific sentinel
+// value, such as io.EOF or custom exported error variables.
+// It supports optional custom error messages through Option.
+//
+// Example:
+//
+//	should.BeErrorIs(t, err, io.EOF)
+//	should.BeErrorIs(t, err, ErrUnauthorized, should.WithMessage("Expected unauthorized error"))
+func BeErrorIs(t *testing.T, err error, target error, opts ...Option) {
+	t.Helper()
+	assert.BeErrorIs(t, err, target)
+}
+
 // BeGreaterThan reports a test failure if the value is not greater than the expected threshold.
 //
 // This assertion works with all numeric types and provides detailed

--- a/should.go
+++ b/should.go
@@ -209,6 +209,22 @@ func BeError(t testing.TB, err error, opts ...Option) {
 	assert.BeError(t, err)
 }
 
+// NotBeError - no error required
+//
+// Verifies that err is nil, ensuring successful operation.
+// Supports optional custom error messages via Option.
+//
+// Example:
+//
+// should.NotBeError(t, err)
+//
+// _, err = os.Open("/nonexistent/file.txt")
+// should.NotBeError(t, err, should.WithMessage("File should exist and be readable"))
+func NotBeError(t testing.TB, err error, opts ...Option) {
+	t.Helper()
+	assert.NotBeError(t, err)
+}
+
 // BeErrorAs reports a test failure if the provided error does not match
 // the target type using errors.As.
 //

--- a/should.go
+++ b/should.go
@@ -232,10 +232,10 @@ func BeError(t testing.TB, err error, opts ...Option) {
 //
 // Example:
 //
-// should.NotBeError(t, err)
+//	should.NotBeError(t, err)
 //
-// _, err = os.Open("/nonexistent/file.txt")
-// should.NotBeError(t, err, should.WithMessage("File should exist and be readable"))
+//	_, err = os.Open("/nonexistent/file.txt")
+//	should.NotBeError(t, err, should.WithMessage("File should exist and be readable"))
 func NotBeError(t testing.TB, err error, opts ...Option) {
 	t.Helper()
 	assert.NotBeError(t, err)

--- a/should_test.go
+++ b/should_test.go
@@ -1,7 +1,10 @@
 package should
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -266,6 +269,25 @@ func TestWrappers(t *testing.T) {
 		if mockT.failed {
 			t.Error("NotBeEqual should pass")
 		}
+	})
+
+	t.Run("BeError passes", func(t *testing.T) {
+		t.Parallel()
+		err := errors.New("something went wrong")
+		BeError(t, err)
+	})
+
+	t.Run("BeErrorAs passes", func(t *testing.T) {
+		t.Parallel()
+		var target *os.PathError
+		err := &os.PathError{Op: "open", Path: "file.txt", Err: errors.New("not found")}
+		BeErrorAs(t, err, &target)
+	})
+
+	t.Run("BeErrorIs passes", func(t *testing.T) {
+		t.Parallel()
+		err := fmt.Errorf("wrapped: %w", io.EOF)
+		BeErrorIs(t, err, io.EOF)
 	})
 
 	// BeGreaterThan

--- a/should_test.go
+++ b/should_test.go
@@ -277,6 +277,12 @@ func TestWrappers(t *testing.T) {
 		BeError(t, err)
 	})
 
+	t.Run("NotBeError passes", func(t *testing.T) {
+		t.Parallel()
+		var err error = nil
+		NotBeError(t, err)
+	})
+
 	t.Run("BeErrorAs passes", func(t *testing.T) {
 		t.Parallel()
 		var target *os.PathError

--- a/should_test.go
+++ b/should_test.go
@@ -288,8 +288,7 @@ func TestWrappers(t *testing.T) {
 
 	t.Run("NotBeError passes", func(t *testing.T) {
 		t.Parallel()
-		var err error = nil
-		NotBeError(t, err)
+		NotBeError(t, nil)
 	})
 
 	t.Run("BeErrorAs passes", func(t *testing.T) {


### PR DESCRIPTION
**docs:** fix formatting of `NotBeError` example in _web docs_.