### PR TITLE
refactor: show explicit length mismatch in slice comparisons

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -685,6 +685,10 @@ func BeEqual(t testing.TB, actual any, expected any, opts ...Option) {
 	var differences []string
 	differencesOutput := "Field differences:\n"
 	for _, diff := range diffs {
+		if diff.Message != "" {
+			differencesOutput = fmt.Sprintf("  └─ %s: %s\n", diff.Path, diff.Message)
+			continue
+		}
 		differencesOutput += fmt.Sprintf("  └─ %s: %s ≠ %s\n", diff.Path, formatDiffValue(diff.Expected), formatDiffValue(diff.Actual))
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -686,7 +686,7 @@ func BeEqual(t testing.TB, actual any, expected any, opts ...Option) {
 	differencesOutput := "Field differences:\n"
 	for _, diff := range diffs {
 		if diff.Message != "" {
-			differencesOutput = fmt.Sprintf("  └─ %s: %s\n", diff.Path, diff.Message)
+			differencesOutput += fmt.Sprintf("  └─ %s: %s\n", diff.Path, diff.Message)
 			continue
 		}
 		differencesOutput += fmt.Sprintf("  └─ %s: %s ≠ %s\n", diff.Path, formatDiffValue(diff.Expected), formatDiffValue(diff.Actual))

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -478,6 +478,36 @@ func TestBeEqual_TypeDifferences(t *testing.T) {
 			},
 		},
 		{
+			name: "struct with slice length difference and value difference",
+			actual: struct {
+				Name   string
+				Ages   []int
+				Scores []float64
+			}{
+				Name:   "João",
+				Ages:   []int{10, 20, 30},
+				Scores: []float64{8.5, 9.5, 7.0},
+			},
+			expected: struct {
+				Name   string
+				Ages   []int
+				Scores []float64
+			}{
+				Name:   "Maria",
+				Ages:   []int{10, 20},
+				Scores: []float64{8.5, 9.0, 7.0},
+			},
+			wantTypeInfo: true,
+			expectedContent: []string{
+				"Not equal:",
+				`expected: {Name: "Maria", Ages: [10, 20], Scores: [8.5, 9, 7]}`,
+				`actual  : {Name: "João", Ages: [10, 20, 30], Scores: [8.5, 9.5, 7]}`,
+				"└─ Name: \"Maria\" ≠ \"João\"",
+				"└─ Ages: length mismatch (expected: 2, actual: 3)",
+				"└─ Scores.[1]: 9 ≠ 9.5",
+			},
+		},
+		{
 			name:         "slice length mismatch",
 			actual:       []int{1, 2, 3},
 			expected:     []int{1, 2},

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -449,6 +449,46 @@ func TestBeEqual_TypeDifferences(t *testing.T) {
 				"└─ : int ≠ ptr",
 			},
 		},
+		{
+			name: "struct with different slice lengths",
+			actual: struct {
+				Name   string
+				Ages   []int
+				Scores []float64
+			}{
+				Name:   "João",
+				Ages:   []int{10, 20, 30},
+				Scores: []float64{8.5, 9},
+			},
+			expected: struct {
+				Name   string
+				Ages   []int
+				Scores []float64
+			}{
+				Name:   "João",
+				Ages:   []int{10, 20},
+				Scores: []float64{8.5, 9},
+			},
+			wantTypeInfo: true,
+			expectedContent: []string{
+				"Not equal:",
+				`expected: {Name: "João", Ages: [10, 20], Scores: [8.5, 9]}`,
+				`actual  : {Name: "João", Ages: [10, 20, 30], Scores: [8.5, 9]}`,
+				"└─ Ages: length mismatch (expected: 2, actual: 3)",
+			},
+		},
+		{
+			name:         "slice length mismatch",
+			actual:       []int{1, 2, 3},
+			expected:     []int{1, 2},
+			wantTypeInfo: true,
+			expectedContent: []string{
+				"Not equal:",
+				"expected: [1, 2]",
+				"actual  : [1, 2, 3]",
+				"└─ : length mismatch (expected: 2, actual: 3)",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/assert/find_differences_test.go
+++ b/assert/find_differences_test.go
@@ -105,7 +105,6 @@ func TestFindDifferences_BasicTypes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := findDifferences(tt.expected, tt.actual)
@@ -170,7 +169,6 @@ func TestFindDifferences_SpecialValues(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := findDifferences(tt.expected, tt.actual)
@@ -346,7 +344,6 @@ func TestFindDifferences_Structs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := findDifferences(tt.expected, tt.actual)
@@ -431,7 +428,6 @@ func TestFindDifferences_PointersAndNil(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := findDifferences(tt.expected, tt.actual)
@@ -466,18 +462,6 @@ func TestFindDifferences_SlicesAndArrays(t *testing.T) {
 					Path:     "[1]",
 					Expected: 2,
 					Actual:   4,
-				},
-			},
-		},
-		{
-			name:     "Different slice lengths",
-			expected: []int{1, 2, 3},
-			actual:   []int{1, 2},
-			want: []fieldDiff{
-				{
-					Path:     "",
-					Expected: []int{1, 2, 3},
-					Actual:   []int{1, 2},
 				},
 			},
 		},
@@ -523,10 +507,20 @@ func TestFindDifferences_SlicesAndArrays(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Different slice lengths",
+			expected: []int{1, 2, 3},
+			actual:   []int{1, 2},
+			want: []fieldDiff{
+				{
+					Path:    "",
+					Message: "length mismatch (expected: 3, actual: 2)",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := findDifferences(tt.expected, tt.actual)
@@ -723,7 +717,6 @@ func TestFindDifferences_Maps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := findDifferences(tt.expected, tt.actual)
@@ -830,7 +823,6 @@ func TestFindDifferences_ComplexNesting(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := findDifferences(tt.expected, tt.actual)
@@ -966,7 +958,6 @@ func TestCompareExpectedActual_ConsistentResultsDespiteMapKeyOrder(t *testing.T)
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/assert/types.go
+++ b/assert/types.go
@@ -11,7 +11,7 @@ type fieldDiff struct {
 	Path     string      // The path to the field, using dot notation for nested fields
 	Expected interface{} // The expected value at this path
 	Actual   interface{} // The actual value at this path
-	Message  string      // Optional message providing additional context about the difference
+	Message  string      // Message provides a custom description of the difference when Expected/Actual are insufficient
 }
 
 // similarItem represents a similar item found

--- a/assert/types.go
+++ b/assert/types.go
@@ -11,6 +11,7 @@ type fieldDiff struct {
 	Path     string      // The path to the field, using dot notation for nested fields
 	Expected interface{} // The expected value at this path
 	Actual   interface{} // The actual value at this path
+	Message  string      // Optional message providing additional context about the difference
 }
 
 // similarItem represents a similar item found

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -273,8 +273,10 @@ func compareExpectedActual(expected, actual interface{}, path string) (diffs []f
 		if expectedValue.Len() != actualValue.Len() {
 			diffs = append(diffs, fieldDiff{
 				Path:     path,
-				Expected: expectedValue.Interface(),
-				Actual:   actualValue.Interface(),
+				Expected: nil,
+				Actual:   nil,
+				Message: fmt.Sprintf("length mismatch (expected: %d, actual: %d)",
+					expectedValue.Len(), actualValue.Len()),
 			})
 			return
 		}


### PR DESCRIPTION
Before:

```go
=== RUN   TestBeEqual_StructWithDifferentSliceSizes
    c:\Users\ACER\should\demo_test.go:180: Differences found:
        Not equal:
        expected: {Name: "João", Ages: [10, 20], Scores: [8.5, 9]}
        actual  : {Name: "João", Ages: [10, 20, 30], Scores: [8.5, 9]}
        Field differences:
          └─ Ages: [10, 20] ≠ [10, 20, 30]
```

After:

```go
--- FAIL: TestBeEqual_StructWithDifferentSliceSizes (0.00s)
    c:\Users\ACER\should\demo_test.go:180: Differences found:
        Not equal:
        expected: {Name: "João", Ages: [10, 20], Scores: [8.5, 9]}
        actual  : {Name: "João", Ages: [10, 20, 30], Scores: [8.5, 9]}
          └─ Ages: length mismatch (expected: 2, actual: 3)
```