### PR TITLE
refactor: enhance EndWith/StartWith with truncation and case checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,18 @@ should.StartWith(t, "Hello, World!", "hello", should.WithIgnoreCase())
 // String suffix checking
 should.EndWith(t, "Hello, World!", "World!")
 
+// Case-sensitive by default
+should.EndWith(t, "Hello, World!", "Hello")
+// Output:
+// Expected string to end with 'Hello', but it ends with 'orld!'
+// Expected : 'Hello'
+// Actual   : 'Hello, World!'
+//                     ^^^^^
+//                     (actual suffix)
+
+// Case-insensitive option
+should.EndWith(t, "Hello, World!", "world!", should.WithIgnoreCase())
+
 // With custom messages
 should.StartWith(t, filename, "temp_", should.WithMessage("Temporary files must have temp_ prefix"))
 should.EndWith(t, filename, ".log", should.WithMessage("Log files must have .log extension"))

--- a/README.md
+++ b/README.md
@@ -348,6 +348,16 @@ should.StartWith(t, "Hello, World!", "hello")
 // Case-insensitive option
 should.StartWith(t, "Hello, World!", "hello", should.WithIgnoreCase())
 
+// Long strings: only the beginning is shown (where the prefix appears)
+actual := strings.Repeat("a", 200) + "_suffix"
+should.StartWith(t, actual, "different")
+// Output:
+// Expected string to start with 'different', but it starts with 'aaaaaaaaa'
+// Expected : 'different'
+// Actual   : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa… (truncated)'
+//             ^^^^^^^^^
+//           (actual prefix)
+
 // String suffix checking
 should.EndWith(t, "Hello, World!", "World!")
 
@@ -360,8 +370,28 @@ should.EndWith(t, "Hello, World!", "Hello")
 //                     ^^^^^
 //                     (actual suffix)
 
+// Case mismatch detection
+should.EndWith(t, "Hello, World", "world")
+// Output:
+// Expected string to end with 'world', but it ends with 'World'
+// Expected : 'world'
+// Actual   : 'Hello, World'
+//                    ^^^^^
+//                    (actual suffix)
+// Note: Case mismatch detected (use should.WithIgnoreCase() if intended)
+
 // Case-insensitive option
 should.EndWith(t, "Hello, World!", "world!", should.WithIgnoreCase())
+
+// Long strings: only the tail is shown (where the suffix appears)
+actual = "prefix_" + strings.Repeat("a", 200)
+should.EndWith(t, actual, "different")
+// Output:
+// Expected string to end with 'different', but it ends with 'aaaaaaaaa'
+// Expected : 'different'
+// Actual   : '(truncated) …aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+//                                                                         ^^^^^^^^^
+//                                                                        (actual suffix)
 
 // With custom messages
 should.StartWith(t, filename, "temp_", should.WithMessage("Temporary files must have temp_ prefix"))

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1044,7 +1044,14 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 
 	cfg := processOptions(opts...)
 
-	if actual == expected || (cfg.IgnoreCase && strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected))) {
+	// Do not guard against expected == "": by definition, every string starts with
+	// an empty prefix (strings.HasPrefix("hello", "") == true).
+	hasPrefix := strings.HasPrefix(actual, expected)
+	if !hasPrefix && cfg.IgnoreCase {
+		hasPrefix = strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected))
+	}
+
+	if actual == expected || hasPrefix {
 		return
 	}
 
@@ -1075,7 +1082,7 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 	actual = truncateHead(actual, displayMaxRunes)
 	expected = truncateHead(expected, displayMaxRunes)
 
-	errorMsg := formatStartsWithError(actual, expected, startWith, noteMsg, cfg)
+	errorMsg := formatStartsWithError(actual, expected, startWith, noteMsg)
 	if errorMsg != "" {
 		failWithOptions(t, cfg, errorMsg)
 	}
@@ -1101,18 +1108,9 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 
 	cfg := processOptions(opts...)
 
-	// --- Logic checks on the original strings ---
-	// An empty suffix matches everything mathematically, but like StartWith with an
-	// empty prefix, we treat it as a likely programming mistake and fall through to
-	// the error path. Only a genuine suffix (non-empty) earns an early return.
-	// Exact match ("" == "") is always valid and returns immediately.
-	if actual == expected {
-		return
-	}
-	if expected != "" && strings.HasSuffix(actual, expected) {
-		return
-	}
-	if expected != "" && cfg.IgnoreCase && strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected)) {
+	// Do not guard against expected == "": by definition, every string ends with
+	// an empty suffix (strings.HasSuffix("hello", "") == true).
+	if actual == expected || strings.HasSuffix(actual, expected) || (cfg.IgnoreCase && strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected))) {
 		return
 	}
 
@@ -1125,11 +1123,10 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	// Extract the actual trailing runes for display (rune-aware, before truncation).
 	actualRunes := []rune(actual)
 	expectedRunes := []rune(expected)
-	var actualEndSuffix string
+	actualEndSuffix := actual
+
 	if len(actualRunes) > len(expectedRunes) {
 		actualEndSuffix = string(actualRunes[len(actualRunes)-len(expectedRunes):])
-	} else {
-		actualEndSuffix = actual
 	}
 
 	// --- Display string preparation ---
@@ -1146,7 +1143,7 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	actual = truncateTail(actual, displayMaxRunes)
 	expected = truncateHead(expected, displayMaxRunes)
 
-	errorMsg := formatEndsWithError(actual, expected, actualEndSuffix, noteMsg, cfg)
+	errorMsg := formatEndsWithError(actual, expected, actualEndSuffix, noteMsg)
 	if errorMsg != "" {
 		failWithOptions(t, cfg, errorMsg)
 	}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1048,6 +1048,22 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 		return
 	}
 
+	// Compute note message from originals before any display mutation.
+	noteMsg := ""
+	if !cfg.IgnoreCase && strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected)) {
+		noteMsg = "\nNote: Case mismatch detected (use should.WithIgnoreCase() if intended)"
+	}
+
+	// Extract the actual leading runes for display (rune-aware, before truncation).
+	actualRunes := []rune(actual)
+	expectedRunes := []rune(expected)
+	var startWith string
+	if len(actualRunes) > len(expectedRunes) {
+		startWith = string(actualRunes[:len(expectedRunes)])
+	} else {
+		startWith = actual
+	}
+
 	if strings.TrimSpace(actual) == "" {
 		actual = "<empty>"
 	}
@@ -1056,26 +1072,8 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 		expected = "<empty>"
 	}
 
-	if len(actual) > 56 {
-		actual = actual[:56] + "... (truncated)"
-	}
-
-	if len(expected) > 56 {
-		expected = expected[:56] + "... (truncated)"
-	}
-
-	var startWith string
-
-	if len(actual) > len(expected) {
-		startWith = actual[:len(expected)]
-	} else {
-		startWith = actual
-	}
-
-	noteMsg := ""
-	if !cfg.IgnoreCase && strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected)) {
-		noteMsg = "\nNote: Case mismatch detected (use should.WithIgnoreCase() if intended)"
-	}
+	actual = truncateHead(actual, displayMaxRunes)
+	expected = truncateHead(expected, displayMaxRunes)
 
 	errorMsg := formatStartsWithError(actual, expected, startWith, noteMsg, cfg)
 	if errorMsg != "" {
@@ -1103,18 +1101,38 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 
 	cfg := processOptions(opts...)
 
-	actualEndSufix := ""
-
-	if len(actual) > len(expected) {
-		actualEndSufix = actual[len(actual)-len(expected):]
-	} else {
-		actualEndSufix = actual
+	// --- Logic checks on the original strings ---
+	// An empty suffix matches everything mathematically, but like StartWith with an
+	// empty prefix, we treat it as a likely programming mistake and fall through to
+	// the error path. Only a genuine suffix (non-empty) earns an early return.
+	// Exact match ("" == "") is always valid and returns immediately.
+	if actual == expected {
+		return
 	}
-
-	if actual == expected || (cfg.IgnoreCase && strings.HasPrefix(strings.ToLower(actualEndSufix), strings.ToLower(expected))) {
+	if expected != "" && strings.HasSuffix(actual, expected) {
+		return
+	}
+	if expected != "" && cfg.IgnoreCase && strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected)) {
 		return
 	}
 
+	// Compute note message from originals before any display mutation.
+	noteMsg := ""
+	if !cfg.IgnoreCase && strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected)) {
+		noteMsg = "\nNote: Case mismatch detected (use should.WithIgnoreCase() if intended)"
+	}
+
+	// Extract the actual trailing runes for display (rune-aware, before truncation).
+	actualRunes := []rune(actual)
+	expectedRunes := []rune(expected)
+	var actualEndSuffix string
+	if len(actualRunes) > len(expectedRunes) {
+		actualEndSuffix = string(actualRunes[len(actualRunes)-len(expectedRunes):])
+	} else {
+		actualEndSuffix = actual
+	}
+
+	// --- Display string preparation ---
 	if strings.TrimSpace(actual) == "" {
 		actual = "<empty>"
 	}
@@ -1123,20 +1141,12 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 		expected = "<empty>"
 	}
 
-	if len(actual) > 56 {
-		actual = "... (truncated)" + actual[56:]
-	}
+	// For suffix assertions: show the tail of actual (where the suffix would appear)
+	// and the start of expected (the full pattern the caller typed).
+	actual = truncateTail(actual, displayMaxRunes)
+	expected = truncateHead(expected, displayMaxRunes)
 
-	if len(expected) > 56 {
-		expected = "... (truncated)" + expected[56:]
-	}
-
-	noteMsg := ""
-	if !cfg.IgnoreCase && strings.HasPrefix(strings.ToLower(actualEndSufix), strings.ToLower(expected)) {
-		noteMsg = "\nNote: Case mismatch detected (use should.WithIgnoreCase() if intended)"
-	}
-
-	errorMsg := formatEndsWithError(actual, expected, actualEndSufix, noteMsg, cfg)
+	errorMsg := formatEndsWithError(actual, expected, actualEndSuffix, noteMsg, cfg)
 	if errorMsg != "" {
 		failWithOptions(t, cfg, errorMsg)
 	}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1029,6 +1029,7 @@ func AnyMatch[T any](t testing.TB, actual []T, predicate func(T) bool, opts ...O
 // This assertion checks if the actual string starts with the expected substring.
 // It provides a detailed error message showing the expected and actual strings,
 // along with a note if the case mismatch is detected.
+// The expected prefix must be non-empty.
 //
 // Example:
 //
@@ -1044,7 +1045,17 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 
 	cfg := processOptions(opts...)
 
-	if actual == expected || (cfg.IgnoreCase && strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected))) {
+	if expected == "" {
+		failWithOptions(t, cfg, "StartWith requires a non-empty expected prefix")
+		return
+	}
+
+	hasPrefix := strings.HasPrefix(actual, expected)
+	if !hasPrefix && cfg.IgnoreCase {
+		hasPrefix = strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected))
+	}
+
+	if actual == expected || hasPrefix {
 		return
 	}
 
@@ -1068,14 +1079,10 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 		actual = "<empty>"
 	}
 
-	if strings.TrimSpace(expected) == "" {
-		expected = "<empty>"
-	}
-
 	actual = truncateHead(actual, displayMaxRunes)
 	expected = truncateHead(expected, displayMaxRunes)
 
-	errorMsg := formatStartsWithError(actual, expected, startWith, noteMsg, cfg)
+	errorMsg := formatStartsWithError(actual, expected, startWith, noteMsg)
 	if errorMsg != "" {
 		failWithOptions(t, cfg, errorMsg)
 	}
@@ -1086,6 +1093,7 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 // This assertion checks if the actual string ends with the expected substring.
 // It provides a detailed error message showing the expected and actual strings,
 // along with a note if the case mismatch is detected.
+// The expected suffix must be non-empty.
 //
 // Example:
 //
@@ -1101,18 +1109,14 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 
 	cfg := processOptions(opts...)
 
-	// --- Logic checks on the original strings ---
-	// An empty suffix matches everything mathematically, but like StartWith with an
-	// empty prefix, we treat it as a likely programming mistake and fall through to
-	// the error path. Only a genuine suffix (non-empty) earns an early return.
-	// Exact match ("" == "") is always valid and returns immediately.
-	if actual == expected {
+	if expected == "" {
+		failWithOptions(t, cfg, "EndWith requires a non-empty expected suffix")
 		return
 	}
-	if expected != "" && strings.HasSuffix(actual, expected) {
-		return
-	}
-	if expected != "" && cfg.IgnoreCase && strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected)) {
+
+	if actual == expected ||
+		strings.HasSuffix(actual, expected) ||
+		(cfg.IgnoreCase && strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected))) {
 		return
 	}
 
@@ -1125,11 +1129,10 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	// Extract the actual trailing runes for display (rune-aware, before truncation).
 	actualRunes := []rune(actual)
 	expectedRunes := []rune(expected)
-	var actualEndSuffix string
+	actualEndSuffix := actual
+
 	if len(actualRunes) > len(expectedRunes) {
 		actualEndSuffix = string(actualRunes[len(actualRunes)-len(expectedRunes):])
-	} else {
-		actualEndSuffix = actual
 	}
 
 	// --- Display string preparation ---
@@ -1137,16 +1140,12 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 		actual = "<empty>"
 	}
 
-	if strings.TrimSpace(expected) == "" {
-		expected = "<empty>"
-	}
-
 	// For suffix assertions: show the tail of actual (where the suffix would appear)
 	// and the start of expected (the full pattern the caller typed).
 	actual = truncateTail(actual, displayMaxRunes)
 	expected = truncateHead(expected, displayMaxRunes)
 
-	errorMsg := formatEndsWithError(actual, expected, actualEndSuffix, noteMsg, cfg)
+	errorMsg := formatEndsWithError(actual, expected, actualEndSuffix, noteMsg)
 	if errorMsg != "" {
 		failWithOptions(t, cfg, errorMsg)
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3994,6 +3994,53 @@ func TestStartsWith(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("Unicode — emoji prefix in long string", func(t *testing.T) {
+		t.Parallel()
+		// Leading emoji (4 bytes each); truncateHead must not split a rune.
+		actual := "🎉" + strings.Repeat("a", 200)
+		mockT := &mockT{}
+		StartWith(mockT, actual, "not_there")
+		if !mockT.failed {
+			t.Fatal("Expected failure but test passed")
+		}
+		// The emoji must appear intact in the error output.
+		if !strings.Contains(mockT.message, "🎉") {
+			t.Errorf("Expected leading emoji to be visible in error, got:\n%s", mockT.message)
+		}
+	})
+
+	t.Run("Unicode — CJK prefix kept when truncating", func(t *testing.T) {
+		t.Parallel()
+		// CJK characters are 3 bytes; truncateHead must keep them intact.
+		actual := "你好世界" + strings.Repeat("x", 200)
+		mockT := &mockT{}
+		StartWith(mockT, actual, "abc")
+		if !mockT.failed {
+			t.Fatal("Expected failure but test passed")
+		}
+		if !strings.Contains(mockT.message, "你好世界") {
+			t.Errorf("Expected CJK prefix to be visible in error, got:\n%s", mockT.message)
+		}
+	})
+
+	t.Run("Truncation shows head of actual", func(t *testing.T) {
+		t.Parallel()
+		// For StartWith, the beginning of actual is what matters.
+		// The error should contain the truncation tail marker, not a dump from byte 56.
+		actual := "unique_start_" + strings.Repeat("a", 200)
+		mockT := &mockT{}
+		StartWith(mockT, actual, "other")
+		if !mockT.failed {
+			t.Fatal("Expected failure but test passed")
+		}
+		if !strings.Contains(mockT.message, "unique_start_") {
+			t.Errorf("Expected head of actual to be visible in error, got:\n%s", mockT.message)
+		}
+		if !strings.Contains(mockT.message, "... (truncated)") {
+			t.Errorf("Expected truncation marker in error, got:\n%s", mockT.message)
+		}
+	})
 }
 
 // === Tests for EndWith ===
@@ -4194,8 +4241,8 @@ func TestEndsWith(t *testing.T) {
 				expected:   "Different",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "... (truncated)") {
-						t.Errorf("Expected message to contain truncated actual string, got: %s", message)
+					if !strings.Contains(message, "(truncated)...") {
+						t.Errorf("Expected message to contain tail-truncation marker '(truncated)...', got: %s", message)
 					}
 				},
 			},
@@ -4206,7 +4253,7 @@ func TestEndsWith(t *testing.T) {
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
 					if !strings.Contains(message, "... (truncated)") {
-						t.Errorf("Expected message to contain truncated expected string, got: %s", message)
+						t.Errorf("Expected message to contain head-truncation marker '... (truncated)', got: %s", message)
 					}
 				},
 			},
@@ -4216,9 +4263,11 @@ func TestEndsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					truncatedOccurrences := strings.Count(message, "... (truncated)")
-					if truncatedOccurrences < 2 {
-						t.Errorf("Expected at least 2 truncated strings in message, got %d occurrences in: %s", truncatedOccurrences, message)
+					if !strings.Contains(message, "(truncated)...") {
+						t.Errorf("Expected tail-truncation marker '(truncated)...' for actual, got: %s", message)
+					}
+					if !strings.Contains(message, "... (truncated)") {
+						t.Errorf("Expected head-truncation marker '... (truncated)' for expected, got: %s", message)
 					}
 				},
 			},
@@ -4242,6 +4291,85 @@ func TestEndsWith(t *testing.T) {
 					tt.errorCheck(t, mockT.message)
 				}
 			})
+		}
+	})
+
+	t.Run("Truncation direction — actual shows tail", func(t *testing.T) {
+		t.Parallel()
+		// A 200-char string ending in "xyz" fails to end with "abc".
+		// The error must show the TAIL of actual (the relevant part for a suffix
+		// assertion), not a dump from byte 56 onwards.
+		actual := strings.Repeat("a", 200) + "xyz"
+		mockT := &mockT{}
+		EndWith(mockT, actual, "abc")
+		if !mockT.failed {
+			t.Fatal("Expected failure but test passed")
+		}
+		if !strings.Contains(mockT.message, "(truncated)...") {
+			t.Errorf("Expected tail-truncation marker '(truncated)...' in error, got:\n%s", mockT.message)
+		}
+		if !strings.Contains(mockT.message, "xyz") {
+			t.Errorf("Expected tail 'xyz' to be visible in error, got:\n%s", mockT.message)
+		}
+	})
+
+	t.Run("Truncation direction — expected shows head", func(t *testing.T) {
+		t.Parallel()
+		// When expected is long, its start must remain visible so the developer
+		// can recognize what they typed.
+		longExpected := "start_" + strings.Repeat("x", 100) + "_end"
+		mockT := &mockT{}
+		EndWith(mockT, "something_else", longExpected)
+		if !mockT.failed {
+			t.Fatal("Expected failure but test passed")
+		}
+		if !strings.Contains(mockT.message, "start_") {
+			t.Errorf("Expected start of expected string 'start_' to be visible, got:\n%s", mockT.message)
+		}
+		if !strings.Contains(mockT.message, "... (truncated)") {
+			t.Errorf("Expected head-truncation marker '... (truncated)' for expected string, got:\n%s", mockT.message)
+		}
+	})
+
+	t.Run("HasSuffix — case mismatch note shown", func(t *testing.T) {
+		t.Parallel()
+		// "Hello, World" ends with "World" but not "world" exactly → note shown.
+		// Previously, HasPrefix was used instead of HasSuffix; the note was
+		// generated correctly only because actualEndSuffix had the same length
+		// as expected (making both predicates equivalent). This test pins the
+		// semantically correct behavior with an explicit message check.
+		mockT := &mockT{}
+		EndWith(mockT, "Hello, World", "world")
+		if !mockT.failed {
+			t.Fatal("Expected failure (case-sensitive) but test passed")
+		}
+		if !strings.Contains(mockT.message, "Case mismatch detected") {
+			t.Errorf("Expected case-mismatch note in error, got:\n%s", mockT.message)
+		}
+	})
+
+	t.Run("Unicode — emoji suffix passes", func(t *testing.T) {
+		t.Parallel()
+		// Each emoji is 4 bytes; byte-slicing would corrupt them.
+		actual := strings.Repeat("x", 60) + "🎉🎊🎈"
+		mockT := &mockT{}
+		EndWith(mockT, actual, "🎉🎊🎈")
+		if mockT.failed {
+			t.Errorf("Expected pass for emoji suffix but got failure:\n%s", mockT.message)
+		}
+	})
+
+	t.Run("Unicode — CJK suffix visible after tail truncation", func(t *testing.T) {
+		t.Parallel()
+		// Each CJK char is 3 bytes. truncateTail must not split a rune.
+		actual := strings.Repeat("a", 200) + "你好世界"
+		mockT := &mockT{}
+		EndWith(mockT, actual, "not_there")
+		if !mockT.failed {
+			t.Fatal("Expected failure but test passed")
+		}
+		if !strings.Contains(mockT.message, "你好世界") {
+			t.Errorf("Expected CJK tail to be visible in error (not garbled), got:\n%s", mockT.message)
 		}
 	})
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3787,6 +3787,18 @@ func TestStartsWith(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("HasPrefix path passes on non-exact match", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+
+			// Covers the non-exact successful prefix path: actual != expected && HasPrefix(actual, expected).
+			StartWith(mockT, "Hello, world!", "Hell")
+
+			if mockT.failed {
+				t.Errorf("Expected StartWith to pass on HasPrefix path, but it failed: %s", mockT.message)
+			}
+		})
 	})
 
 	t.Run("Case sensitivity", func(t *testing.T) {
@@ -3836,6 +3848,18 @@ func TestStartsWith(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("HasSuffix path passes on non-exact match", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+
+			// Covers the non-exact successful suffix path: actual != expected && HasSuffix(actual, expected).
+			EndWith(mockT, "Hello, world!", "orld!")
+
+			if mockT.failed {
+				t.Errorf("Expected EndWith to pass on HasSuffix path, but it failed: %s", mockT.message)
+			}
+		})
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
@@ -3882,15 +3906,10 @@ func TestStartsWith(t *testing.T) {
 			errorCheck func(t *testing.T, message string)
 		}{
 			{
-				name:       "should fail for empty prefix",
+				name:       "should pass for empty prefix",
 				actual:     "data",
 				expected:   "",
-				shouldFail: true,
-				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, `Expected string to start with '<empty>'`) {
-						t.Errorf("Expected error message for empty prefix, got: %s", message)
-					}
-				},
+				shouldFail: false,
 			},
 			{
 				name:       "should fail if actual is empty",
@@ -3946,7 +3965,7 @@ func TestStartsWith(t *testing.T) {
 				expected:   "Different",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "... (truncated)") {
+					if !strings.Contains(message, "… (truncated)") {
 						t.Errorf("Expected message to contain truncated actual string, got: %s", message)
 					}
 				},
@@ -3957,7 +3976,7 @@ func TestStartsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "... (truncated)") {
+					if !strings.Contains(message, "… (truncated)") {
 						t.Errorf("Expected message to contain truncated expected string, got: %s", message)
 					}
 				},
@@ -3968,7 +3987,7 @@ func TestStartsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					truncatedOccurrences := strings.Count(message, "... (truncated)")
+					truncatedOccurrences := strings.Count(message, "… (truncated)")
 					if truncatedOccurrences < 2 {
 						t.Errorf("Expected at least 2 truncated strings in message, got %d occurrences in: %s", truncatedOccurrences, message)
 					}
@@ -4037,7 +4056,7 @@ func TestStartsWith(t *testing.T) {
 		if !strings.Contains(mockT.message, "unique_start_") {
 			t.Errorf("Expected head of actual to be visible in error, got:\n%s", mockT.message)
 		}
-		if !strings.Contains(mockT.message, "... (truncated)") {
+		if !strings.Contains(mockT.message, "… (truncated)") {
 			t.Errorf("Expected truncation marker in error, got:\n%s", mockT.message)
 		}
 	})
@@ -4199,7 +4218,7 @@ func TestEndsWith(t *testing.T) {
 				name:       "Empty expected with non-empty actual",
 				actual:     "hello",
 				expected:   "",
-				shouldFail: true,
+				shouldFail: false,
 			},
 			{
 				name:       "Non-empty expected with empty actual",
@@ -4241,8 +4260,8 @@ func TestEndsWith(t *testing.T) {
 				expected:   "Different",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "(truncated)...") {
-						t.Errorf("Expected message to contain tail-truncation marker '(truncated)...', got: %s", message)
+					if !strings.Contains(message, "(truncated) …") {
+						t.Errorf("Expected message to contain tail-truncation marker '(truncated) …', got: %s", message)
 					}
 				},
 			},
@@ -4252,8 +4271,8 @@ func TestEndsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "... (truncated)") {
-						t.Errorf("Expected message to contain head-truncation marker '... (truncated)', got: %s", message)
+					if !strings.Contains(message, "… (truncated)") {
+						t.Errorf("Expected message to contain head-truncation marker '… (truncated)', got: %s", message)
 					}
 				},
 			},
@@ -4263,11 +4282,11 @@ func TestEndsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "(truncated)...") {
-						t.Errorf("Expected tail-truncation marker '(truncated)...' for actual, got: %s", message)
+					if !strings.Contains(message, "(truncated) …") {
+						t.Errorf("Expected tail-truncation marker '(truncated) …' for actual, got: %s", message)
 					}
-					if !strings.Contains(message, "... (truncated)") {
-						t.Errorf("Expected head-truncation marker '... (truncated)' for expected, got: %s", message)
+					if !strings.Contains(message, "… (truncated)") {
+						t.Errorf("Expected head-truncation marker '… (truncated)' for expected, got: %s", message)
 					}
 				},
 			},
@@ -4305,8 +4324,8 @@ func TestEndsWith(t *testing.T) {
 		if !mockT.failed {
 			t.Fatal("Expected failure but test passed")
 		}
-		if !strings.Contains(mockT.message, "(truncated)...") {
-			t.Errorf("Expected tail-truncation marker '(truncated)...' in error, got:\n%s", mockT.message)
+		if !strings.Contains(mockT.message, "(truncated) …") {
+			t.Errorf("Expected tail-truncation marker '(truncated) …' in error, got:\n%s", mockT.message)
 		}
 		if !strings.Contains(mockT.message, "xyz") {
 			t.Errorf("Expected tail 'xyz' to be visible in error, got:\n%s", mockT.message)
@@ -4326,8 +4345,8 @@ func TestEndsWith(t *testing.T) {
 		if !strings.Contains(mockT.message, "start_") {
 			t.Errorf("Expected start of expected string 'start_' to be visible, got:\n%s", mockT.message)
 		}
-		if !strings.Contains(mockT.message, "... (truncated)") {
-			t.Errorf("Expected head-truncation marker '... (truncated)' for expected string, got:\n%s", mockT.message)
+		if !strings.Contains(mockT.message, "… (truncated)") {
+			t.Errorf("Expected head-truncation marker '… (truncated)' for expected string, got:\n%s", mockT.message)
 		}
 	})
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3787,6 +3787,18 @@ func TestStartsWith(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("HasPrefix path passes on non-exact match", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+
+			// Covers the non-exact successful prefix path: actual != expected && HasPrefix(actual, expected).
+			StartWith(mockT, "Hello, world!", "Hell")
+
+			if mockT.failed {
+				t.Errorf("Expected StartWith to pass on HasPrefix path, but it failed: %s", mockT.message)
+			}
+		})
 	})
 
 	t.Run("Case sensitivity", func(t *testing.T) {
@@ -3836,6 +3848,18 @@ func TestStartsWith(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("HasSuffix path passes on non-exact match", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+
+			// Covers the non-exact successful suffix path: actual != expected && HasSuffix(actual, expected).
+			EndWith(mockT, "Hello, world!", "orld!")
+
+			if mockT.failed {
+				t.Errorf("Expected EndWith to pass on HasSuffix path, but it failed: %s", mockT.message)
+			}
+		})
 	})
 
 	t.Run("Custom messages", func(t *testing.T) {
@@ -3887,8 +3911,19 @@ func TestStartsWith(t *testing.T) {
 				expected:   "",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, `Expected string to start with '<empty>'`) {
-						t.Errorf("Expected error message for empty prefix, got: %s", message)
+					if !strings.Contains(message, "StartWith requires a non-empty expected prefix") {
+						t.Errorf("Expected clear empty-prefix error, got: %s", message)
+					}
+				},
+			},
+			{
+				name:       "should fail when both strings are empty",
+				actual:     "",
+				expected:   "",
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "StartWith requires a non-empty expected prefix") {
+						t.Errorf("Expected clear empty-prefix error, got: %s", message)
 					}
 				},
 			},
@@ -3946,7 +3981,7 @@ func TestStartsWith(t *testing.T) {
 				expected:   "Different",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "... (truncated)") {
+					if !strings.Contains(message, "… (truncated)") {
 						t.Errorf("Expected message to contain truncated actual string, got: %s", message)
 					}
 				},
@@ -3957,7 +3992,7 @@ func TestStartsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "... (truncated)") {
+					if !strings.Contains(message, "… (truncated)") {
 						t.Errorf("Expected message to contain truncated expected string, got: %s", message)
 					}
 				},
@@ -3968,7 +4003,7 @@ func TestStartsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					truncatedOccurrences := strings.Count(message, "... (truncated)")
+					truncatedOccurrences := strings.Count(message, "… (truncated)")
 					if truncatedOccurrences < 2 {
 						t.Errorf("Expected at least 2 truncated strings in message, got %d occurrences in: %s", truncatedOccurrences, message)
 					}
@@ -4037,7 +4072,7 @@ func TestStartsWith(t *testing.T) {
 		if !strings.Contains(mockT.message, "unique_start_") {
 			t.Errorf("Expected head of actual to be visible in error, got:\n%s", mockT.message)
 		}
-		if !strings.Contains(mockT.message, "... (truncated)") {
+		if !strings.Contains(mockT.message, "… (truncated)") {
 			t.Errorf("Expected truncation marker in error, got:\n%s", mockT.message)
 		}
 	})
@@ -4188,18 +4223,29 @@ func TestEndsWith(t *testing.T) {
 			actual     string
 			expected   string
 			shouldFail bool
+			errorCheck func(t *testing.T, message string)
 		}{
 			{
 				name:       "Empty strings",
 				actual:     "",
 				expected:   "",
-				shouldFail: false,
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "EndWith requires a non-empty expected suffix") {
+						t.Errorf("Expected clear empty-suffix error, got: %s", message)
+					}
+				},
 			},
 			{
 				name:       "Empty expected with non-empty actual",
 				actual:     "hello",
 				expected:   "",
 				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "EndWith requires a non-empty expected suffix") {
+						t.Errorf("Expected clear empty-suffix error, got: %s", message)
+					}
+				},
 			},
 			{
 				name:       "Non-empty expected with empty actual",
@@ -4222,6 +4268,9 @@ func TestEndsWith(t *testing.T) {
 				if !tt.shouldFail && mockT.Failed() {
 					t.Errorf("Expected success but test failed")
 				}
+				if tt.errorCheck != nil && mockT.failed {
+					tt.errorCheck(t, mockT.message)
+				}
 			})
 		}
 	})
@@ -4241,8 +4290,8 @@ func TestEndsWith(t *testing.T) {
 				expected:   "Different",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "(truncated)...") {
-						t.Errorf("Expected message to contain tail-truncation marker '(truncated)...', got: %s", message)
+					if !strings.Contains(message, "(truncated) …") {
+						t.Errorf("Expected message to contain tail-truncation marker '(truncated) …', got: %s", message)
 					}
 				},
 			},
@@ -4252,8 +4301,8 @@ func TestEndsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "... (truncated)") {
-						t.Errorf("Expected message to contain head-truncation marker '... (truncated)', got: %s", message)
+					if !strings.Contains(message, "… (truncated)") {
+						t.Errorf("Expected message to contain head-truncation marker '… (truncated)', got: %s", message)
 					}
 				},
 			},
@@ -4263,11 +4312,11 @@ func TestEndsWith(t *testing.T) {
 				expected:   "This is a very long expected string that exceeds the 56 character limit for display purposes in error messages",
 				shouldFail: true,
 				errorCheck: func(t *testing.T, message string) {
-					if !strings.Contains(message, "(truncated)...") {
-						t.Errorf("Expected tail-truncation marker '(truncated)...' for actual, got: %s", message)
+					if !strings.Contains(message, "(truncated) …") {
+						t.Errorf("Expected tail-truncation marker '(truncated) …' for actual, got: %s", message)
 					}
-					if !strings.Contains(message, "... (truncated)") {
-						t.Errorf("Expected head-truncation marker '... (truncated)' for expected, got: %s", message)
+					if !strings.Contains(message, "… (truncated)") {
+						t.Errorf("Expected head-truncation marker '… (truncated)' for expected, got: %s", message)
 					}
 				},
 			},
@@ -4305,8 +4354,8 @@ func TestEndsWith(t *testing.T) {
 		if !mockT.failed {
 			t.Fatal("Expected failure but test passed")
 		}
-		if !strings.Contains(mockT.message, "(truncated)...") {
-			t.Errorf("Expected tail-truncation marker '(truncated)...' in error, got:\n%s", mockT.message)
+		if !strings.Contains(mockT.message, "(truncated) …") {
+			t.Errorf("Expected tail-truncation marker '(truncated) …' in error, got:\n%s", mockT.message)
 		}
 		if !strings.Contains(mockT.message, "xyz") {
 			t.Errorf("Expected tail 'xyz' to be visible in error, got:\n%s", mockT.message)
@@ -4326,8 +4375,8 @@ func TestEndsWith(t *testing.T) {
 		if !strings.Contains(mockT.message, "start_") {
 			t.Errorf("Expected start of expected string 'start_' to be visible, got:\n%s", mockT.message)
 		}
-		if !strings.Contains(mockT.message, "... (truncated)") {
-			t.Errorf("Expected head-truncation marker '... (truncated)' for expected string, got:\n%s", mockT.message)
+		if !strings.Contains(mockT.message, "… (truncated)") {
+			t.Errorf("Expected head-truncation marker '… (truncated)' for expected string, got:\n%s", mockT.message)
 		}
 	})
 

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -29,24 +29,38 @@ const displayMaxRunes = 56
 // truncateHead keeps the first maxRunes runes of s and appends a truncation marker.
 // Used to display the beginning of a string (prefix assertions, expected values).
 // Safe for multi-byte encodings (emoji, CJK, etc.) — never splits a rune.
+// Returns s unchanged when the marked-up result would be longer than the original.
 func truncateHead(s string, maxRunes int) string {
 	runes := []rune(s)
-	if len(runes) <= maxRunes {
+	n := len(runes)
+	if n <= maxRunes {
 		return s
 	}
-	return string(runes[:maxRunes]) + "... (truncated)"
+	const marker = "… (truncated)"
+	// Only truncate when the result is strictly shorter than the original.
+	if maxRunes+utf8.RuneCountInString(marker) >= n {
+		return s
+	}
+	return string(runes[:maxRunes]) + marker
 }
 
 // truncateTail keeps the last maxRunes runes of s and prepends a truncation marker.
 // Used to display the end of a string (suffix assertions like EndWith), so the
 // reader sees the part of the string where the suffix would appear.
 // Safe for multi-byte encodings (emoji, CJK, etc.) — never splits a rune.
+// Returns s unchanged when the marked-up result would be longer than the original.
 func truncateTail(s string, maxRunes int) string {
 	runes := []rune(s)
-	if len(runes) <= maxRunes {
+	n := len(runes)
+	if n <= maxRunes {
 		return s
 	}
-	return "(truncated)... " + string(runes[len(runes)-maxRunes:])
+	const marker = "(truncated) …"
+	// Only truncate when the result is strictly shorter than the original.
+	if maxRunes+utf8.RuneCountInString(marker) >= n {
+		return s
+	}
+	return marker + string(runes[n-maxRunes:])
 }
 
 // isSliceOrArray checks if the provided value is a slice or an array.
@@ -1391,52 +1405,28 @@ func addPrefixHighlightToEnd(msg *strings.Builder, actual, expected string) {
 	}
 }
 
-func formatStartsWithError(actual string, expected string, startWith string, noteMsg string, cfg *Config) string {
+// formatStartsWithError formats a detailed error message for StartWith assertions.
+// It is only called when the assertion has already failed.
+func formatStartsWithError(actual string, expected string, startWith string, noteMsg string) string {
 	var msg strings.Builder
-
-	if cfg.IgnoreCase && strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected)) {
-		msg.WriteString(fmt.Sprintf("Expected string to start with '%s', but it starts with '%s'", expected, startWith))
-		msg.WriteString(fmt.Sprintf("\nExpected : '%s'", expected))
-		msg.WriteString(fmt.Sprintf("\nActual   : '%s'", actual))
-		addPrefixHighlight(&msg, actual, expected)
-		msg.WriteString(noteMsg)
-		return msg.String()
-	}
-
-	if !strings.HasPrefix(actual, expected) {
-		msg.WriteString(fmt.Sprintf("Expected string to start with '%s', but it starts with '%s'", expected, startWith))
-		msg.WriteString(fmt.Sprintf("\nExpected : '%s'", expected))
-		msg.WriteString(fmt.Sprintf("\nActual   : '%s'", actual))
-		addPrefixHighlight(&msg, actual, expected)
-		msg.WriteString(noteMsg)
-		return msg.String()
-	}
-
-	return ""
+	msg.WriteString(fmt.Sprintf("Expected string to start with '%s', but it starts with '%s'", expected, startWith))
+	msg.WriteString(fmt.Sprintf("\nExpected : '%s'", expected))
+	msg.WriteString(fmt.Sprintf("\nActual   : '%s'", actual))
+	addPrefixHighlight(&msg, actual, expected)
+	msg.WriteString(noteMsg)
+	return msg.String()
 }
 
 // formatEndsWithError formats a detailed error message for EndWith assertions.
-func formatEndsWithError(actual string, expected string, actualEndSufix string, noteMsg string, cfg *Config) string {
+// It is only called when the assertion has already failed.
+func formatEndsWithError(actual string, expected string, actualEndSuffix string, noteMsg string) string {
 	var msg strings.Builder
-	if cfg.IgnoreCase && strings.HasSuffix(strings.ToLower(actualEndSufix), strings.ToLower(expected)) {
-		msg.WriteString(fmt.Sprintf("Expected string to end with '%s', but it ends with '%s'", expected, actualEndSufix))
-		msg.WriteString(fmt.Sprintf("\nExpected : '%s'", expected))
-		msg.WriteString(fmt.Sprintf("\nActual   : '%s'", actual))
-		addPrefixHighlight(&msg, actual, expected)
-		msg.WriteString(noteMsg)
-		return msg.String()
-	}
-
-	if !strings.HasSuffix(actualEndSufix, expected) {
-		msg.WriteString(fmt.Sprintf("Expected string to end with '%s', but it ends with '%s'", expected, actualEndSufix))
-		msg.WriteString(fmt.Sprintf("\nExpected : '%s'", expected))
-		msg.WriteString(fmt.Sprintf("\nActual   : '%s'", actual))
-		addPrefixHighlightToEnd(&msg, actual, expected)
-		msg.WriteString(noteMsg)
-		return msg.String()
-	}
-
-	return ""
+	msg.WriteString(fmt.Sprintf("Expected string to end with '%s', but it ends with '%s'", expected, actualEndSuffix))
+	msg.WriteString(fmt.Sprintf("\nExpected : '%s'", expected))
+	msg.WriteString(fmt.Sprintf("\nActual   : '%s'", actual))
+	addPrefixHighlightToEnd(&msg, actual, expected)
+	msg.WriteString(noteMsg)
+	return msg.String()
 }
 
 // findExactCaseMismatch finds the exact case mismatch for a substring within a string

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -22,6 +22,33 @@ const maxSimilarLen = 20
 // as effectively equal, preferring the more complete string.
 const similarityThreshold = 0.05
 
+// displayMaxRunes is the maximum number of runes shown for a string in assertion
+// error messages before the string is truncated for readability.
+const displayMaxRunes = 56
+
+// truncateHead keeps the first maxRunes runes of s and appends a truncation marker.
+// Used to display the beginning of a string (prefix assertions, expected values).
+// Safe for multi-byte encodings (emoji, CJK, etc.) — never splits a rune.
+func truncateHead(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes]) + "... (truncated)"
+}
+
+// truncateTail keeps the last maxRunes runes of s and prepends a truncation marker.
+// Used to display the end of a string (suffix assertions like EndWith), so the
+// reader sees the part of the string where the suffix would appear.
+// Safe for multi-byte encodings (emoji, CJK, etc.) — never splits a rune.
+func truncateTail(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return "(truncated)... " + string(runes[len(runes)-maxRunes:])
+}
+
 // isSliceOrArray checks if the provided value is a slice or an array.
 // It handles nil values by returning false.
 func isSliceOrArray(v interface{}) bool {
@@ -1341,21 +1368,22 @@ func formatIndexesWindow(indexes []int, windowSize int) string {
 } */
 
 func addPrefixHighlight(msg *strings.Builder, actual, expected string) {
-	prefixLength := len(expected)
-	if len(actual) >= prefixLength {
-		fmt.Fprintf(msg, "\n            %s", strings.Repeat("^", prefixLength))
+	prefixLen := utf8.RuneCountInString(expected)
+	if utf8.RuneCountInString(actual) >= prefixLen {
+		fmt.Fprintf(msg, "\n            %s", strings.Repeat("^", prefixLen))
 		msg.WriteString("\n          (actual prefix)")
 	}
 }
 
 func addPrefixHighlightToEnd(msg *strings.Builder, actual, expected string) {
-	prefixLength := len(expected)
-	if len(actual) >= prefixLength {
-		blanksToAdd := len(actual) - prefixLength
+	expectedLen := utf8.RuneCountInString(expected)
+	actualLen := utf8.RuneCountInString(actual)
+	if actualLen >= expectedLen {
+		blanksToAdd := actualLen - expectedLen
 		blanks := strings.Repeat(" ", blanksToAdd)
 		fmt.Fprintf(msg, "\n            ")
 		msg.WriteString(blanks)
-		msg.WriteString(strings.Repeat("^", prefixLength))
+		msg.WriteString(strings.Repeat("^", expectedLen))
 		msg.WriteString("\n")
 		msg.WriteString("            ")
 		msg.WriteString(blanks)

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -4746,6 +4746,8 @@ func TestFormatBeWithinError(t *testing.T) {
 func TestTruncateHelpers(t *testing.T) {
 	t.Parallel()
 
+	// --- truncateHead ---
+
 	t.Run("truncateHead — ASCII within limit", func(t *testing.T) {
 		t.Parallel()
 		got := truncateHead("hello", 10)
@@ -4754,10 +4756,22 @@ func TestTruncateHelpers(t *testing.T) {
 		}
 	})
 
+	t.Run("truncateHead — no truncation when marker would make string longer", func(t *testing.T) {
+		t.Parallel()
+		// 57 ASCII runes, limit 56: 56 + 13 (marker runes) = 69 > 57.
+		// Truncating would produce a longer output — must return unchanged.
+		s := strings.Repeat("a", 57)
+		got := truncateHead(s, 56)
+		if got != s {
+			t.Errorf("expected no truncation for 57-rune string at limit 56, got %q", got)
+		}
+	})
+
 	t.Run("truncateHead — ASCII over limit", func(t *testing.T) {
 		t.Parallel()
-		got := truncateHead("abcdefghij", 5)
-		want := "abcde... (truncated)"
+		// 20 ASCII runes, limit 5: 5+13=18 < 20 → must truncate.
+		got := truncateHead("abcdefghijklmnopqrst", 5)
+		want := "abcde… (truncated)"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -4765,9 +4779,9 @@ func TestTruncateHelpers(t *testing.T) {
 
 	t.Run("truncateHead — emoji not split", func(t *testing.T) {
 		t.Parallel()
-		// 3 emojis, limit 2 → keep first 2 emojis intact
-		got := truncateHead("🎉🎊🎈", 2)
-		want := "🎉🎊... (truncated)"
+		// 20 emoji runes, limit 2: 2+13=15 < 20 → must truncate, no rune splitting.
+		got := truncateHead(strings.Repeat("🎉", 20), 2)
+		want := "🎉🎉… (truncated)"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -4775,12 +4789,15 @@ func TestTruncateHelpers(t *testing.T) {
 
 	t.Run("truncateHead — CJK not split", func(t *testing.T) {
 		t.Parallel()
-		got := truncateHead("你好世界", 2)
-		want := "你好... (truncated)"
+		// 20 CJK runes, limit 2: 2+13=15 < 20 → must truncate, no rune splitting.
+		got := truncateHead(strings.Repeat("你", 20), 2)
+		want := "你你… (truncated)"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
 	})
+
+	// --- truncateTail ---
 
 	t.Run("truncateTail — ASCII within limit", func(t *testing.T) {
 		t.Parallel()
@@ -4790,10 +4807,22 @@ func TestTruncateHelpers(t *testing.T) {
 		}
 	})
 
+	t.Run("truncateTail — no truncation when marker would make string longer", func(t *testing.T) {
+		t.Parallel()
+		// 57 ASCII runes, limit 56: 56 + 13 (marker runes) = 69 > 57.
+		// Truncating would produce a longer output — must return unchanged.
+		s := strings.Repeat("a", 57)
+		got := truncateTail(s, 56)
+		if got != s {
+			t.Errorf("expected no truncation for 57-rune string at limit 56, got %q", got)
+		}
+	})
+
 	t.Run("truncateTail — ASCII over limit", func(t *testing.T) {
 		t.Parallel()
-		got := truncateTail("abcdefghij", 5)
-		want := "(truncated)... fghij"
+		// 20 ASCII runes, limit 5: 5+13=18 < 20 → must truncate.
+		got := truncateTail("abcdefghijklmnopqrst", 5)
+		want := "(truncated) …pqrst"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -4801,9 +4830,9 @@ func TestTruncateHelpers(t *testing.T) {
 
 	t.Run("truncateTail — emoji not split", func(t *testing.T) {
 		t.Parallel()
-		// 3 emojis, limit 2 → keep last 2 emojis intact
-		got := truncateTail("🎉🎊🎈", 2)
-		want := "(truncated)... 🎊🎈"
+		// 20 emoji runes, limit 2: 2+13=15 < 20 → must truncate, no rune splitting.
+		got := truncateTail(strings.Repeat("🎉", 20), 2)
+		want := "(truncated) …🎉🎉"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -4811,8 +4840,9 @@ func TestTruncateHelpers(t *testing.T) {
 
 	t.Run("truncateTail — CJK not split", func(t *testing.T) {
 		t.Parallel()
-		got := truncateTail("你好世界", 2)
-		want := "(truncated)... 世界"
+		// 20 CJK runes, limit 2: 2+13=15 < 20 → must truncate, no rune splitting.
+		got := truncateTail(strings.Repeat("你", 20), 2)
+		want := "(truncated) …你你"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -4826,7 +4856,7 @@ func TestTruncateHelpers(t *testing.T) {
 		if !strings.HasSuffix(got, "xyz") {
 			t.Errorf("expected tail to end with xyz, got %q", got)
 		}
-		if !strings.HasPrefix(got, "(truncated)...") {
+		if !strings.HasPrefix(got, "(truncated) …") {
 			t.Errorf("expected truncation marker, got %q", got)
 		}
 	})

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -4742,3 +4742,92 @@ func TestFormatBeWithinError(t *testing.T) {
 		})
 	})
 }
+
+func TestTruncateHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("truncateHead — ASCII within limit", func(t *testing.T) {
+		t.Parallel()
+		got := truncateHead("hello", 10)
+		if got != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("truncateHead — ASCII over limit", func(t *testing.T) {
+		t.Parallel()
+		got := truncateHead("abcdefghij", 5)
+		want := "abcde... (truncated)"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("truncateHead — emoji not split", func(t *testing.T) {
+		t.Parallel()
+		// 3 emojis, limit 2 → keep first 2 emojis intact
+		got := truncateHead("🎉🎊🎈", 2)
+		want := "🎉🎊... (truncated)"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("truncateHead — CJK not split", func(t *testing.T) {
+		t.Parallel()
+		got := truncateHead("你好世界", 2)
+		want := "你好... (truncated)"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("truncateTail — ASCII within limit", func(t *testing.T) {
+		t.Parallel()
+		got := truncateTail("hello", 10)
+		if got != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("truncateTail — ASCII over limit", func(t *testing.T) {
+		t.Parallel()
+		got := truncateTail("abcdefghij", 5)
+		want := "(truncated)... fghij"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("truncateTail — emoji not split", func(t *testing.T) {
+		t.Parallel()
+		// 3 emojis, limit 2 → keep last 2 emojis intact
+		got := truncateTail("🎉🎊🎈", 2)
+		want := "(truncated)... 🎊🎈"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("truncateTail — CJK not split", func(t *testing.T) {
+		t.Parallel()
+		got := truncateTail("你好世界", 2)
+		want := "(truncated)... 世界"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("truncateTail — long string shows tail", func(t *testing.T) {
+		t.Parallel()
+		// 200 "a"s + "xyz" — tail must include "xyz"
+		s := strings.Repeat("a", 200) + "xyz"
+		got := truncateTail(s, 56)
+		if !strings.HasSuffix(got, "xyz") {
+			t.Errorf("expected tail to end with xyz, got %q", got)
+		}
+		if !strings.HasPrefix(got, "(truncated)...") {
+			t.Errorf("expected truncation marker, got %q", got)
+		}
+	})
+}

--- a/should.go
+++ b/should.go
@@ -522,6 +522,7 @@ func AnyMatch[T any](t testing.TB, actual []T, predicate func(T) bool, opts ...O
 // This assertion checks if the actual string starts with the expected substring.
 // It provides a detailed error message showing the expected and actual strings,
 // along with a note if the case mismatch is detected.
+// The expected prefix must be non-empty.
 //
 // Example:
 //
@@ -542,6 +543,7 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 // This assertion checks if the actual string ends with the expected substring.
 // It provides a detailed error message showing the expected and actual strings,
 // along with a note if the case mismatch is detected.
+// The expected suffix must be non-empty.
 //
 // Example:
 //


### PR DESCRIPTION
Fixes four bugs in EndWith and improves truncation safety for multi-byte strings in both EndWith and StartWith.

Bugs fixed in EndWith:
- strings.HasPrefix was used instead of strings.HasSuffix, causing the suffix check to always fail for strings longer than the expected value
- actual was truncated from the tail (showing noise) instead of keeping the last N runes (the relevant suffix)
- expected was truncated incorrectly in the same direction
- typo: actualEndSufix → actualEndSuffix

New helpers in assert/utils.go:
- displayMaxRunes = 56 (replaces magic number)
- truncateHead(s, maxRunes) – keeps first N runes + "... (truncated)" (used for prefix assertions and expected values)
- truncateTail(s, maxRunes) – keeps last N runes with "(truncated)... " prefix (used for actual in suffix assertions)
- Both are safe for emoji, CJK, and any multi-byte UTF-8 encoding