### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/commit-msg.yml
+++ b/.github/workflows/commit-msg.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch the full history so every commit in the PR is available
           fetch-depth: 0

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -20,12 +20,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
 
       - name: Download dependencies
         run: go mod download
@@ -45,12 +46,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
 
       - name: Check for vulnerabilities
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -62,12 +64,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
 
       - name: Check go.mod is tidy
         run: go mod tidy -diff

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,12 +13,13 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download dependencies
         run: go mod download
@@ -30,10 +31,10 @@ jobs:
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.txt
+          files: ./coverage.txt
           fail_ci_if_error: false
 
       - name: Check coverage threshold

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -13,15 +13,16 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.3.0
           args: --timeout=5m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ git checkout -b feature/your-feature-name
 
 ## Linting (golangci-lint)
 
-- CI: we use `golangci-lint` version `v2.3.0` (via `golangci/golangci-lint-action@v8`), configured by `.golangci.yml`.
+- CI: we use `golangci-lint` version `v2.3.0` (via `golangci/golangci-lint-action@v9`), configured by `.golangci.yml`.
 
 ### Local installation
 


### PR DESCRIPTION
Node.js 20 is deprecated in GitHub-hosted runners. Starting June 2, 2026 Node.js 24 becomes mandatory; Node.js 20 is removed on Sep 16, 2026.