### PR TITLE
feat: add NotEndWith assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ should.NotContainValue(t, userRoles, 3)
 
 - `StartWith(t, actual, expected)` - Check if string starts with expected substring
 - `EndWith(t, actual, expected)` - Check if string ends with expected substring
+- `NotEndWith(t, actual, suffix)` - Check if string does NOT end with expected suffix
 - `ContainSubstring(t, actual, substring)` - Check if string contains expected substring
 
 ### Collection Operations

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1151,6 +1151,60 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	}
 }
 
+// NotEndWith reports a test failure if the string ends with the expected suffix.
+//
+// This assertion checks if the actual string ends with the expected substring
+// and fails if it does. It supports optional [WithIgnoreCase] and [WithMessage].
+// The expected suffix must be non-empty.
+//
+// Example:
+//
+//	should.NotEndWith(t, "Hello, world!", "planet")
+//
+//	should.NotEndWith(t, "Hello, world", "WORLD", should.WithIgnoreCase())
+//
+//	should.NotEndWith(t, "/safe/path", "/admin", should.WithMessage("Path must not end with /admin"))
+func NotEndWith(t testing.TB, actual string, expected string, opts ...Option) {
+	t.Helper()
+
+	cfg := processOptions(opts...)
+
+	if expected == "" {
+		failWithOptions(t, cfg, "NotEndWith requires a non-empty expected suffix")
+		return
+	}
+
+	hasSuffix := strings.HasSuffix(actual, expected)
+	if !hasSuffix && cfg.IgnoreCase {
+		hasSuffix = strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected))
+	}
+
+	if !hasSuffix {
+		return
+	}
+
+	// Extract the actual trailing runes for display (rune-aware, before truncation).
+	actualRunes := []rune(actual)
+	expectedRunes := []rune(expected)
+	actualEndSuffix := actual
+
+	if len(actualRunes) > len(expectedRunes) {
+		actualEndSuffix = string(actualRunes[len(actualRunes)-len(expectedRunes):])
+	}
+
+	if strings.TrimSpace(actual) == "" {
+		actual = "<empty>"
+	}
+
+	actual = truncateTail(actual, displayMaxRunes)
+	expected = truncateHead(expected, displayMaxRunes)
+
+	errorMsg := formatNotEndsWithError(actual, expected, actualEndSuffix)
+	if errorMsg != "" {
+		failWithOptions(t, cfg, errorMsg)
+	}
+}
+
 // ContainSubstring reports a test failure if the string does not contain the expected substring.
 //
 // This assertion checks if the actual string contains the expected substring.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -4423,6 +4423,198 @@ func TestEndsWith(t *testing.T) {
 	})
 }
 
+// === Tests for NotEndWith ===
+
+func TestNotEndsWith(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			actual     string
+			expected   string
+			shouldFail bool
+		}{
+			{
+				name:       "Success when actual does not end with expected",
+				actual:     "Hello, world!",
+				expected:   "planet",
+				shouldFail: false,
+			},
+			{
+				name:       "Fails when actual ends with expected",
+				actual:     "Hello, world!",
+				expected:   "world!",
+				shouldFail: true,
+			},
+			{
+				name:       "Exact match fails",
+				actual:     "world",
+				expected:   "world",
+				shouldFail: true,
+			},
+			{
+				name:       "Expected longer than actual",
+				actual:     "abc",
+				expected:   "abcdef",
+				shouldFail: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mockT := &mockT{}
+				NotEndWith(mockT, tt.actual, tt.expected)
+
+				if tt.shouldFail && !mockT.Failed() {
+					t.Errorf("Expected failure but test passed")
+				}
+				if !tt.shouldFail && mockT.Failed() {
+					t.Errorf("Expected success but test failed")
+				}
+			})
+		}
+	})
+
+	t.Run("Case sensitivity", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			actual     string
+			expected   string
+			opts       []Option
+			shouldFail bool
+		}{
+			{
+				name:       "Fails with ignore case when actual ends with expected ignoring case",
+				actual:     "Hello, WORLD",
+				expected:   "world",
+				opts:       []Option{WithIgnoreCase()},
+				shouldFail: true,
+			},
+			{
+				name:       "Passes with ignore case disabled when case differs",
+				actual:     "Hello, WORLD",
+				expected:   "world",
+				opts:       []Option{},
+				shouldFail: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mockT := &mockT{}
+				NotEndWith(mockT, tt.actual, tt.expected, tt.opts...)
+
+				if tt.shouldFail && !mockT.Failed() {
+					t.Errorf("Expected failure but test passed")
+				}
+				if !tt.shouldFail && mockT.Failed() {
+					t.Errorf("Expected success but test failed")
+				}
+			})
+		}
+	})
+
+	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Fails with custom message", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+			NotEndWith(mockT, "Hello, world!", "world!", WithMessage("String should not end with 'world!'"))
+
+			if !mockT.Failed() {
+				t.Errorf("Expected failure but test passed")
+			}
+
+			expectedStrings := []string{
+				"Expected string to NOT end with 'world!'",
+				"but it does",
+			}
+
+			for _, expectedString := range expectedStrings {
+				if !strings.Contains(mockT.message, expectedString) {
+					t.Errorf("Expected message to contain %q, but got %q", expectedString, mockT.message)
+				}
+			}
+		})
+	})
+
+	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			actual     string
+			expected   string
+			shouldFail bool
+			errorCheck func(t *testing.T, message string)
+		}{
+			{
+				name:       "Empty expected with empty actual",
+				actual:     "",
+				expected:   "",
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "NotEndWith requires a non-empty expected suffix") {
+						t.Errorf("Expected clear empty-suffix error, got: %s", message)
+					}
+				},
+			},
+			{
+				name:       "Empty expected with non-empty actual",
+				actual:     "hello",
+				expected:   "",
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "NotEndWith requires a non-empty expected suffix") {
+						t.Errorf("Expected clear empty-suffix error, got: %s", message)
+					}
+				},
+			},
+			{
+				name:       "Non-empty expected with empty actual",
+				actual:     "",
+				expected:   "hello",
+				shouldFail: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mockT := &mockT{}
+				NotEndWith(mockT, tt.actual, tt.expected)
+
+				if tt.shouldFail && !mockT.Failed() {
+					t.Errorf("Expected failure but test passed")
+				}
+				if !tt.shouldFail && mockT.Failed() {
+					t.Errorf("Expected success but test failed")
+				}
+				if tt.errorCheck != nil && mockT.failed {
+					tt.errorCheck(t, mockT.message)
+				}
+			})
+		}
+	})
+
+	t.Run("Unicode — emoji suffix passes", func(t *testing.T) {
+		t.Parallel()
+		actual := strings.Repeat("x", 60) + "🎉🎊🎈"
+		mockT := &mockT{}
+		NotEndWith(mockT, actual, "world")
+		if mockT.failed {
+			t.Errorf("Expected pass for non-matching suffix but got failure:\n%s", mockT.message)
+		}
+	})
+}
+
 // === Tests for BeEqual with complex types and custom messages ===
 
 func TestBeEqual_WithComplexNestedStructs_CustomMessage(t *testing.T) {

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -1429,6 +1429,17 @@ func formatEndsWithError(actual string, expected string, actualEndSuffix string,
 	return msg.String()
 }
 
+// formatNotEndsWithError formats a detailed error message for NotEndWith assertions.
+// It is only called when the assertion has already failed.
+func formatNotEndsWithError(actual string, expected string, actualEndSuffix string) string {
+	var msg strings.Builder
+	msg.WriteString(fmt.Sprintf("Expected string to NOT end with '%s', but it does:", expected))
+	msg.WriteString(fmt.Sprintf("\nSuffix   : '%s'", expected))
+	msg.WriteString(fmt.Sprintf("\nActual   : '%s'", actualEndSuffix))
+	addPrefixHighlightToEnd(&msg, actualEndSuffix, expected)
+	return msg.String()
+}
+
 // findExactCaseMismatch finds the exact case mismatch for a substring within a string
 // Returns the position and the found substring if there's an exact case-only difference
 func findExactCaseMismatch(actual, substring string) caseMismatchResult {

--- a/should.go
+++ b/should.go
@@ -559,6 +559,24 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	assert.EndWith(t, actual, expected, opts...)
 }
 
+// NotEndWith reports a test failure if the string ends with the expected suffix.
+//
+// This assertion checks if the actual string ends with the expected substring
+// and fails if it does. It supports optional [WithIgnoreCase] and [WithMessage].
+// The expected suffix must be non-empty.
+//
+// Example:
+//
+//	should.NotEndWith(t, "Hello, world!", "planet")
+//
+//	should.NotEndWith(t, "Hello, world", "WORLD", should.WithIgnoreCase())
+//
+//	should.NotEndWith(t, "/safe/path", "/admin", should.WithMessage("Path must not end with /admin"))
+func NotEndWith(t testing.TB, actual string, expected string, opts ...Option) {
+	t.Helper()
+	assert.NotEndWith(t, actual, expected, opts...)
+}
+
 // ContainSubstring reports a test failure if the string does not contain the expected substring.
 //
 // This assertion checks if the actual string contains the expected substring.

--- a/should_test.go
+++ b/should_test.go
@@ -478,6 +478,24 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 
+	t.Run("NotEndWith passes", func(t *testing.T) {
+		t.Parallel()
+		mockT := &mockTB{}
+		NotEndWith(mockT, "Hello, world!", "planet")
+		if mockT.failed {
+			t.Error("NotEndWith should pass")
+		}
+	})
+
+	t.Run("NotEndWith fails", func(t *testing.T) {
+		t.Parallel()
+		mockT := &mockTB{}
+		NotEndWith(mockT, "Hello, world", "world")
+		if !mockT.failed {
+			t.Error("NotEndWith should fail")
+		}
+	})
+
 	// AnyMatch
 	t.Run("AnyMatch passes", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Description
Adds the negative counterpart of EndWith — NotEndWith. It reports a test failure when a string ends with an unwanted suffix, supporting WithIgnoreCase() and WithMessage() options.

## Changes
- `assert/assertions.go`: Implemented NotEndWith core logic
- `assert/utils.go`: Added formatNotEndsWithError for clear error messages
- `assert/assertions_test.go`: Added comprehensive unit tests (basic, case sensitivity, custom messages, edge cases, unicode)
- `should.go`: Exposed NotEndWith in the public API
- `should_test.go`: Added integration tests
- `README.md`: Added NotEndWith to the assertions list

## Type of Change
- [x] Bug fix
- [x] Enhancement

## Testing
- Pre-fix: N/A (new feature)
- Post-fix: `go test ./...` — both packages pass
- All existing tests continue to pass

## Related Issue
Fixes #67