### PR TITLE
feat: add NotEndWith assertion (fixes #67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,20 @@ should.EndWith(t, actual, "different")
 // With custom messages
 should.StartWith(t, filename, "temp_", should.WithMessage("Temporary files must have temp_ prefix"))
 should.EndWith(t, filename, ".log", should.WithMessage("Log files must have .log extension"))
+
+// Negated suffix checking
+should.NotEndWith(t, "Hello, world!", "planet")  // passes
+should.NotEndWith(t, "Hello, world!", "world!") // fails
+// Output:
+// Expected string to NOT end with 'world!', but it does
+// Expected : 'world!'
+// Actual   : 'Hello, world!'
+
+// Case-insensitive negated suffix
+should.NotEndWith(t, "Hello, WORLD", "world", should.WithIgnoreCase()) // fails
+
+// With custom messages
+should.NotEndWith(t, filename, ".tmp", should.WithMessage("Output files must not have .tmp extension"))
 ```
 
 ### String Substring Assertions
@@ -716,6 +730,7 @@ should.NotContainValue(t, userRoles, 3)
 
 - `StartWith(t, actual, expected)` - Check if string starts with expected substring
 - `EndWith(t, actual, expected)` - Check if string ends with expected substring
+- `NotEndWith(t, actual, expected)` - Check if string does NOT end with expected substring
 - `ContainSubstring(t, actual, substring)` - Check if string contains expected substring
 
 ### Collection Operations

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1182,6 +1182,12 @@ func NotEndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	}
 
 	if actual == expected || hasSuffix {
+		// Match EndWith display preparation so tail excerpts stay rune-aware for
+		// emoji, CJK, and other multi-byte characters.
+		if strings.TrimSpace(actual) == "" {
+			actual = "<empty>"
+		}
+
 		displayActual := truncateTail(actual, displayMaxRunes)
 		displayExpected := truncateHead(expected, displayMaxRunes)
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1151,6 +1151,46 @@ func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	}
 }
 
+// NotEndWith reports a test failure if the string ends with the expected substring.
+//
+// This assertion checks if the actual string does NOT end with the expected substring.
+// It provides a detailed error message showing the expected and actual strings.
+// The expected suffix must be non-empty.
+//
+// Example:
+//
+//	should.NotEndWith(t, "Hello, world!", "planet")
+//
+//	should.NotEndWith(t, "Hello, WORLD", "world", should.WithIgnoreCase()) // fails
+//
+//	should.NotEndWith(t, "Hello, world!", "world", should.WithMessage("String should not end with 'world'"))
+//
+// Note: The assertion is case-sensitive by default. Use [WithIgnoreCase] to ignore case.
+func NotEndWith(t testing.TB, actual string, expected string, opts ...Option) {
+	t.Helper()
+
+	cfg := processOptions(opts...)
+
+	if expected == "" {
+		failWithOptions(t, cfg, "NotEndWith requires a non-empty expected suffix")
+		return
+	}
+
+	hasSuffix := strings.HasSuffix(actual, expected)
+	if !hasSuffix && cfg.IgnoreCase {
+		hasSuffix = strings.HasSuffix(strings.ToLower(actual), strings.ToLower(expected))
+	}
+
+	if actual == expected || hasSuffix {
+		displayActual := truncateTail(actual, displayMaxRunes)
+		displayExpected := truncateHead(expected, displayMaxRunes)
+
+		errorMsg := fmt.Sprintf("Expected string to NOT end with '%s', but it does\nExpected : '%s'\nActual   : '%s'",
+			displayExpected, displayExpected, displayActual)
+		failWithOptions(t, cfg, errorMsg)
+	}
+}
+
 // ContainSubstring reports a test failure if the string does not contain the expected substring.
 //
 // This assertion checks if the actual string contains the expected substring.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -4641,6 +4641,50 @@ func TestNotEndsWith(t *testing.T) {
 				t.Errorf("Expected truncation marker in error, got:\n%s", mockT.message)
 			}
 		})
+
+		t.Run("Whitespace-only actual is rendered as empty placeholder", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+			NotEndWith(mockT, "   ", " ")
+			if !mockT.failed {
+				t.Fatal("Expected failure but test passed")
+			}
+			if !strings.Contains(mockT.message, "Actual   : '<empty>'") {
+				t.Errorf("Expected whitespace-only actual to render as <empty>, got:\n%s", mockT.message)
+			}
+		})
+
+		t.Run("Unicode — emoji suffix visible after tail truncation", func(t *testing.T) {
+			t.Parallel()
+			longActual := strings.Repeat("a", 200) + "🎉🎊🎈"
+			mockT := &mockT{}
+			NotEndWith(mockT, longActual, "🎉🎊🎈")
+			if !mockT.failed {
+				t.Fatal("Expected failure but test passed")
+			}
+			if !strings.Contains(mockT.message, "🎉🎊🎈") {
+				t.Errorf("Expected emoji suffix to be visible in error (not garbled), got:\n%s", mockT.message)
+			}
+			if !strings.Contains(mockT.message, "(truncated)") {
+				t.Errorf("Expected truncation marker in error, got:\n%s", mockT.message)
+			}
+		})
+
+		t.Run("Unicode — CJK suffix visible after tail truncation", func(t *testing.T) {
+			t.Parallel()
+			longActual := strings.Repeat("a", 200) + "你好世界"
+			mockT := &mockT{}
+			NotEndWith(mockT, longActual, "你好世界")
+			if !mockT.failed {
+				t.Fatal("Expected failure but test passed")
+			}
+			if !strings.Contains(mockT.message, "你好世界") {
+				t.Errorf("Expected CJK suffix to be visible in error (not garbled), got:\n%s", mockT.message)
+			}
+			if !strings.Contains(mockT.message, "(truncated)") {
+				t.Errorf("Expected truncation marker in error, got:\n%s", mockT.message)
+			}
+		})
 	})
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -4423,6 +4423,227 @@ func TestEndsWith(t *testing.T) {
 	})
 }
 
+// === Tests for NotEndWith ===
+
+func TestNotEndsWith(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Basic functionality", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			actual     string
+			expected   string
+			shouldFail bool
+			errorCheck func(t *testing.T, message string)
+		}{
+			{
+				name:       "Success when actual does not end with expected",
+				actual:     "Hello, world!",
+				expected:   "planet",
+				shouldFail: false,
+			},
+			{
+				name:       "Failure when actual ends with expected",
+				actual:     "Hello, world!",
+				expected:   "world!",
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "Expected string to NOT end with") {
+						t.Errorf("Expected 'NOT end with' message, got:\n%s", message)
+					}
+				},
+			},
+			{
+				name:       "Failure on exact match",
+				actual:     "world",
+				expected:   "world",
+				shouldFail: true,
+			},
+			{
+				name:       "Success when expected is longer than actual",
+				actual:     "abc",
+				expected:   "abcdef",
+				shouldFail: false,
+			},
+			{
+				name:       "Success when suffix does not match",
+				actual:     "Hello, world!",
+				expected:   "Hello",
+				shouldFail: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mockT := &mockT{}
+				NotEndWith(mockT, tt.actual, tt.expected)
+
+				if tt.shouldFail && !mockT.Failed() {
+					t.Errorf("Expected failure but test passed")
+				}
+				if !tt.shouldFail && mockT.Failed() {
+					t.Errorf("Expected success but test failed: %s", mockT.message)
+				}
+
+				if tt.errorCheck != nil && mockT.failed {
+					tt.errorCheck(t, mockT.message)
+				}
+			})
+		}
+	})
+
+	t.Run("Case sensitivity", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			actual     string
+			expected   string
+			opts       []Option
+			shouldFail bool
+		}{
+			{
+				name:       "Success without ignore case when case differs",
+				actual:     "Hello, WORLD",
+				expected:   "world",
+				opts:       []Option{},
+				shouldFail: false,
+			},
+			{
+				name:       "Failure with ignore case enabled when case-insensitive match exists",
+				actual:     "Hello, WORLD",
+				expected:   "world",
+				opts:       []Option{WithIgnoreCase()},
+				shouldFail: true,
+			},
+			{
+				name:       "Success with ignore case when suffix does not match at all",
+				actual:     "Hello, WORLD",
+				expected:   "planet",
+				opts:       []Option{WithIgnoreCase()},
+				shouldFail: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mockT := &mockT{}
+				NotEndWith(mockT, tt.actual, tt.expected, tt.opts...)
+
+				if tt.shouldFail && !mockT.Failed() {
+					t.Errorf("Expected failure but test passed")
+				}
+				if !tt.shouldFail && mockT.Failed() {
+					t.Errorf("Expected success but test failed: %s", mockT.message)
+				}
+			})
+		}
+	})
+
+	t.Run("Custom messages", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Fails with custom message", func(t *testing.T) {
+			t.Parallel()
+			mockT := &mockT{}
+			NotEndWith(mockT, "Hello, world!", "world!", WithMessage("String should not end with 'world!'"))
+
+			if !mockT.Failed() {
+				t.Errorf("Expected failure but test passed")
+			}
+
+			expectedStrings := []string{
+				"String should not end with 'world!'",
+				"Expected string to NOT end with",
+			}
+
+			for _, expectedString := range expectedStrings {
+				if !strings.Contains(mockT.message, expectedString) {
+					t.Errorf("Expected message to contain %q, but got %q", expectedString, mockT.message)
+				}
+			}
+		})
+	})
+
+	t.Run("Edge cases", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name       string
+			actual     string
+			expected   string
+			shouldFail bool
+			errorCheck func(t *testing.T, message string)
+		}{
+			{
+				name:       "Empty strings",
+				actual:     "",
+				expected:   "",
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "NotEndWith requires a non-empty expected suffix") {
+						t.Errorf("Expected clear empty-suffix error, got: %s", message)
+					}
+				},
+			},
+			{
+				name:       "Empty expected with non-empty actual",
+				actual:     "hello",
+				expected:   "",
+				shouldFail: true,
+				errorCheck: func(t *testing.T, message string) {
+					if !strings.Contains(message, "NotEndWith requires a non-empty expected suffix") {
+						t.Errorf("Expected clear empty-suffix error, got: %s", message)
+					}
+				},
+			},
+			{
+				name:       "Non-empty expected with empty actual",
+				actual:     "",
+				expected:   "hello",
+				shouldFail: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mockT := &mockT{}
+				NotEndWith(mockT, tt.actual, tt.expected)
+
+				if tt.shouldFail && !mockT.Failed() {
+					t.Errorf("Expected failure but test passed")
+				}
+				if !tt.shouldFail && mockT.Failed() {
+					t.Errorf("Expected success but test failed: %s", mockT.message)
+				}
+				if tt.errorCheck != nil && mockT.failed {
+					tt.errorCheck(t, mockT.message)
+				}
+			})
+		}
+	})
+
+	t.Run("String truncation", func(t *testing.T) {
+		t.Parallel()
+		t.Run("should truncate long actual string in error message", func(t *testing.T) {
+			t.Parallel()
+			longActual := strings.Repeat("a", 200) + "xyz"
+			mockT := &mockT{}
+			NotEndWith(mockT, longActual, "xyz")
+			if !mockT.failed {
+				t.Fatal("Expected failure but test passed")
+			}
+			if !strings.Contains(mockT.message, "(truncated)") {
+				t.Errorf("Expected truncation marker in error, got:\n%s", mockT.message)
+			}
+		})
+	})
+}
+
 // === Tests for BeEqual with complex types and custom messages ===
 
 func TestBeEqual_WithComplexNestedStructs_CustomMessage(t *testing.T) {

--- a/should.go
+++ b/should.go
@@ -55,12 +55,13 @@ func WithMessagef(message string, args ...any) Option {
 // WithIgnoreCase returns an option that makes string comparisons case-insensitive.
 //
 // This option can be passed to assertions that perform string comparisons,
-// such as [StartWith] and [EndWith], to ensure that case differences are ignored.
+// such as [StartWith], [EndWith], and [NotEndWith], to ensure that case differences are ignored.
 //
 // Example:
 //
 //	should.StartWith(t, "hello", "HELLO", should.WithIgnoreCase())
 //	should.EndWith(t, "Hello, world", "WORLD", should.WithIgnoreCase())
+//	should.NotEndWith(t, "Hello, WORLD", "world", should.WithIgnoreCase())
 func WithIgnoreCase() Option {
 	return assert.WithIgnoreCase()
 }
@@ -557,6 +558,26 @@ func StartWith(t testing.TB, actual string, expected string, opts ...Option) {
 func EndWith(t testing.TB, actual string, expected string, opts ...Option) {
 	t.Helper()
 	assert.EndWith(t, actual, expected, opts...)
+}
+
+// NotEndWith reports a test failure if the string ends with the expected substring.
+//
+// This assertion checks if the actual string does NOT end with the expected substring.
+// It provides a detailed error message showing the expected and actual strings.
+// The expected suffix must be non-empty.
+//
+// Example:
+//
+//	should.NotEndWith(t, "Hello, world!", "planet")
+//
+//	should.NotEndWith(t, "Hello, WORLD", "world", should.WithIgnoreCase()) // fails
+//
+//	should.NotEndWith(t, "Hello, world!", "world", should.WithMessage("String should not end with 'world'"))
+//
+// Note: The assertion is case-sensitive by default. Use [WithIgnoreCase] to ignore case.
+func NotEndWith(t testing.TB, actual string, expected string, opts ...Option) {
+	t.Helper()
+	assert.NotEndWith(t, actual, expected, opts...)
 }
 
 // ContainSubstring reports a test failure if the string does not contain the expected substring.

--- a/should_test.go
+++ b/should_test.go
@@ -478,6 +478,23 @@ func TestWrappers(t *testing.T) {
 		}
 	})
 
+	t.Run("NotEndWith passes", func(t *testing.T) {
+		t.Parallel()
+		mockT := &mockTB{}
+		NotEndWith(mockT, "Hello, world", "planet")
+		if mockT.failed {
+			t.Error("NotEndWith should pass")
+		}
+	})
+	t.Run("NotEndWith fails", func(t *testing.T) {
+		t.Parallel()
+		mockT := &mockTB{}
+		NotEndWith(mockT, "Hello, world", "world")
+		if !mockT.failed {
+			t.Error("NotEndWith should fail")
+		}
+	})
+
 	// AnyMatch
 	t.Run("AnyMatch passes", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
This PR resolves #67 by introducing the NotEndWith string assertion. It behaves as the logical inverse of the existing EndWith assertion, checking if an actual string does not end with an expected suffix.

Changes Made
Core Implementation: Added NotEndWith to assert/assertions.go. It natively supports should.WithMessage() and should.WithIgnoreCase() by reusing the existing option processing logic.
API Wrapper: Added the NotEndWith wrapper function to should.go, maintaining docstring parity with the assert package (verified via wrapper_parity_test.go).
Unit Testing: Added extensive unit tests (TestNotEndsWith) covering basic functionality, case sensitivity (ignoring and respecting case), custom messages, string truncation for long strings, and edge cases (e.g. empty strings).
Integration Testing: Added pass/fail integration tests to should_test.go.
Documentation: Updated README.md to include examples of how to use NotEndWith alongside the other string prefix and suffix assertions. Also updated the WithIgnoreCase documentation in should.go to explicitly mention NotEndWith.
Related Issue
Fixes #67

Testing
go test ./... passes successfully.
Manually verified that long string truncation output matches the rest of the library's design.