### PR TITLE
fix: slice multi-byte strings on rune boundaries in error preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ should.ContainSubstring(t, apiResponse, "success", should.WithIgnoreCase(), shou
 
 **Note**: Typo detection using Levenshtein distance is automatically enabled for substrings up to 20 characters to maintain good performance. For longer substrings, only exact matching is performed.
 
+**Known limitation**: Multiline previews of long strings are sliced on rune (code point) boundaries, so multi-byte characters are never corrupted in the output. They are not sliced on grapheme-cluster boundaries, so a combined sequence such as an emoji ZWJ sequence (for example, a family emoji) can still be split across two preview lines. This affects only the rendered error preview, never the assertion result.
+
 ### Duplicate Detection
 
 Ensure collections contain no duplicate values with detailed reporting:

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -405,19 +405,34 @@ func buildPath(parent, field string) string {
 // Otherwise, it shows up to 5 initial lines (56 chars each), and if longer,
 // appends the last 3 lines for context.
 func formatMultilineString(s string) string {
-	if len(s) < 280 {
+	const (
+		// byteThreshold: shorter strings are shown verbatim; longer ones get the
+		// truncated multi-line summary below.
+		byteThreshold = 280
+		// lineWidth: characters per preview line.
+		lineWidth = 56
+		// headLines / tailLines: how many leading and trailing lines to show.
+		headLines = 5
+		tailLines = 3
+	)
+
+	if len(s) < byteThreshold {
 		return s
 	}
 
 	// Work in runes, not bytes: slicing on byte offsets can cut through a
 	// multi-byte UTF-8 sequence and emit U+FFFD replacement characters, and
 	// len(s) would report the byte count where the header promises characters.
+	// This preserves whole code points, not whole grapheme clusters: an emoji
+	// ZWJ sequence or a base+combining-mark pair can still be split between
+	// runes. Grapheme-aware segmentation is out of scope for an error preview
+	// and would need a Unicode segmentation dependency.
 	runes := []rune(s)
 	totalRunes := len(runes)
 
 	builder := strings.Builder{}
 
-	totalLine := totalRunes / 56
+	totalLine := totalRunes / lineWidth
 
 	builder.WriteString("Length: ")
 	builder.WriteString(fmt.Sprintf("%d", totalRunes))
@@ -425,30 +440,30 @@ func formatMultilineString(s string) string {
 	builder.WriteString(fmt.Sprintf("%d lines", totalLine))
 	builder.WriteString("\n")
 
-	// max 5 lines and 56 characters per line
-	for i := range 5 {
-		start := i * 56
+	// writeLine appends the 1-indexed preview line that starts at rune i*lineWidth,
+	// clamped to the end of the string. Lines whose start is past the end are
+	// skipped, so a string of N runes that is fewer than headLines lines long
+	// stops cleanly without indexing past the slice.
+	writeLine := func(i int) {
+		start := i * lineWidth
 		if start >= totalRunes {
-			break
+			return
 		}
 		builder.WriteString(fmt.Sprintf("%d. ", i+1))
-		builder.WriteString(string(runes[start:min(start+56, totalRunes)]))
+		builder.WriteString(string(runes[start:min(start+lineWidth, totalRunes)]))
 		builder.WriteString("\n")
 	}
 
-	if totalLine > 5 {
+	for i := range headLines {
+		writeLine(i)
+	}
+
+	if totalLine > headLines {
 		builder.WriteString("\n")
 		builder.WriteString("Last lines:\n")
 
-		// print last 3 lines
-		for i := totalLine - 3; i < totalLine; i++ {
-			start := i * 56
-			if start >= totalRunes {
-				break
-			}
-			builder.WriteString(fmt.Sprintf("%d. ", i+1))
-			builder.WriteString(string(runes[start:min(start+56, totalRunes)]))
-			builder.WriteString("\n")
+		for i := totalLine - tailLines; i < totalLine; i++ {
+			writeLine(i)
 		}
 	}
 

--- a/assert/utils.go
+++ b/assert/utils.go
@@ -409,20 +409,30 @@ func formatMultilineString(s string) string {
 		return s
 	}
 
+	// Work in runes, not bytes: slicing on byte offsets can cut through a
+	// multi-byte UTF-8 sequence and emit U+FFFD replacement characters, and
+	// len(s) would report the byte count where the header promises characters.
+	runes := []rune(s)
+	totalRunes := len(runes)
+
 	builder := strings.Builder{}
 
-	totalLine := len(s) / 56
+	totalLine := totalRunes / 56
 
 	builder.WriteString("Length: ")
-	builder.WriteString(fmt.Sprintf("%d", len(s)))
+	builder.WriteString(fmt.Sprintf("%d", totalRunes))
 	builder.WriteString(" characters, ")
 	builder.WriteString(fmt.Sprintf("%d lines", totalLine))
 	builder.WriteString("\n")
 
 	// max 5 lines and 56 characters per line
 	for i := range 5 {
+		start := i * 56
+		if start >= totalRunes {
+			break
+		}
 		builder.WriteString(fmt.Sprintf("%d. ", i+1))
-		builder.WriteString(s[i*56 : min(i*56+56, len(s))])
+		builder.WriteString(string(runes[start:min(start+56, totalRunes)]))
 		builder.WriteString("\n")
 	}
 
@@ -432,8 +442,12 @@ func formatMultilineString(s string) string {
 
 		// print last 3 lines
 		for i := totalLine - 3; i < totalLine; i++ {
+			start := i * 56
+			if start >= totalRunes {
+				break
+			}
 			builder.WriteString(fmt.Sprintf("%d. ", i+1))
-			builder.WriteString(s[i*56 : min(i*56+56, len(s))])
+			builder.WriteString(string(runes[start:min(start+56, totalRunes)]))
 			builder.WriteString("\n")
 		}
 	}

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -990,6 +990,54 @@ func TestFormatMultilineString(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Multi-byte CJK string is not split mid-rune", func(t *testing.T) {
+		t.Parallel()
+		// 100 CJK runes = 300 UTF-8 bytes, past the 280-byte threshold so the
+		// multiline formatter runs. Byte-based slicing would cut through a
+		// 3-byte rune and emit U+FFFD; rune-based slicing must not.
+		input := strings.Repeat("中", 100)
+		result := formatMultilineString(input)
+
+		if strings.ContainsRune(result, '\uFFFD') {
+			t.Errorf("Expected no U+FFFD replacement characters\n\nFull result:\n%s", result)
+		}
+		if !strings.Contains(result, "Length: 100 characters") {
+			t.Errorf("Expected rune count 100 in header, got:\n%s", result)
+		}
+	})
+
+	t.Run("Emoji string is not split mid-rune", func(t *testing.T) {
+		t.Parallel()
+		// 100 emoji runes = 400 UTF-8 bytes (4 bytes each).
+		input := strings.Repeat("🎉", 100)
+		result := formatMultilineString(input)
+
+		if strings.ContainsRune(result, '\uFFFD') {
+			t.Errorf("Expected no U+FFFD replacement characters\n\nFull result:\n%s", result)
+		}
+		if !strings.Contains(result, "Length: 100 characters") {
+			t.Errorf("Expected rune count 100 in header, got:\n%s", result)
+		}
+	})
+
+	t.Run("Accented string spanning last lines preserves runes", func(t *testing.T) {
+		t.Parallel()
+		// 400 accented runes = 800 UTF-8 bytes (2 bytes each), long enough to
+		// trigger the "Last lines" section so both slicing loops are exercised.
+		input := strings.Repeat("é", 400)
+		result := formatMultilineString(input)
+
+		if strings.ContainsRune(result, '\uFFFD') {
+			t.Errorf("Expected no U+FFFD replacement characters\n\nFull result:\n%s", result)
+		}
+		if !strings.Contains(result, "Length: 400 characters") {
+			t.Errorf("Expected rune count 400 in header, got:\n%s", result)
+		}
+		if !strings.Contains(result, "Last lines:") {
+			t.Errorf("Expected 'Last lines:' section, got:\n%s", result)
+		}
+	})
 }
 
 func TestIsSliceOrArray(t *testing.T) {

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -1007,9 +1007,10 @@ func TestFormatMultilineString(t *testing.T) {
 		}
 	})
 
-	t.Run("Emoji string is not split mid-rune", func(t *testing.T) {
+	t.Run("Single-code-point emoji is not split mid-rune", func(t *testing.T) {
 		t.Parallel()
-		// 100 emoji runes = 400 UTF-8 bytes (4 bytes each).
+		// 🎉 (U+1F389) is a single code point: 100 runes = 400 UTF-8 bytes.
+		// Rune-based slicing keeps each one whole.
 		input := strings.Repeat("🎉", 100)
 		result := formatMultilineString(input)
 
@@ -1018,6 +1019,27 @@ func TestFormatMultilineString(t *testing.T) {
 		}
 		if !strings.Contains(result, "Length: 100 characters") {
 			t.Errorf("Expected rune count 100 in header, got:\n%s", result)
+		}
+	})
+
+	t.Run("ZWJ grapheme cluster is sliced at code-point granularity (known limitation)", func(t *testing.T) {
+		t.Parallel()
+		// A ZWJ emoji sequence is several code points joined by U+200D, so a
+		// preview line boundary can fall inside one cluster. should slices on
+		// runes, not grapheme clusters, so that split is accepted: making it
+		// grapheme-aware would require a Unicode segmentation dependency. What
+		// must still hold is that rune-slicing never emits U+FFFD and the header
+		// reports the code-point count, not the grapheme count.
+		cluster := "\U0001F9D1\U0001F3FD\u200D\u2764\uFE0F\u200D\U0001F9D1\U0001F3FF" // couple with heart, mixed skin tones
+		input := strings.Repeat(cluster, 40)                                          // 320 runes, ~1120 bytes
+		result := formatMultilineString(input)
+
+		if strings.ContainsRune(result, '\uFFFD') {
+			t.Errorf("Expected no U+FFFD replacement characters\n\nFull result:\n%s", result)
+		}
+		wantRunes := len([]rune(input))
+		if !strings.Contains(result, fmt.Sprintf("Length: %d characters", wantRunes)) {
+			t.Errorf("Expected code-point count %d in header, got:\n%s", wantRunes, result)
 		}
 	})
 


### PR DESCRIPTION
## What

`formatMultilineString` (`assert/utils.go`) builds the multi-line preview shown when `BeEmpty`, `NotBeEmpty`, or `ContainSubstring` fail on a long string. It sliced the input on **byte** offsets (`s[i*56 : ...]`) and reported `len(s)` as the character count.

For strings containing multi-byte runes (CJK, emoji, accented letters) a slice boundary can land inside a UTF-8 sequence, so Go emits `U+FFFD` replacement characters, and the header reports the byte count where it promises characters.

Before (`should.BeEmpty(t, strings.Repeat("中", 100))`):

```text
Length: 300 characters, 5 lines
1. 中中中中中中中中中中中中中中中中中中�
2. �中中中中中中中中中中中中中中中中中中�
3. ��中中中中中中中中中中中中中中中中中中
...
```

After:

```text
Length: 100 characters, 1 lines
1. 中中中中中中中中中中中中中中中中中中中中...
2. ...
```

## How

Convert to `[]rune` once and slice on rune indices, mirroring `truncateHead` / `truncateTail` in the same file, which already handle multi-byte input correctly. Each line's start offset is bounds-checked so a string that clears the 280-byte threshold but holds fewer than 280 runes no longer indexes past the slice.

The byte-based trigger threshold is unchanged, so the formatter still kicks in for the same inputs; only the count and the slicing become rune-correct. ASCII output is byte-for-byte identical.

## Testing

Added three sub-tests to `TestFormatMultilineString` (CJK, emoji, and accented strings, the last long enough to exercise the "Last lines" branch). Each asserts the header reports the rune count and that no `U+FFFD` appears. Verified they fail on the current code and pass with the change.

```
go test -race -cover ./...
ok  github.com/Kairum-Labs/should         coverage: 100.0% of statements
ok  github.com/Kairum-Labs/should/assert  coverage: 96.3% of statements
golangci-lint run ./assert/...  # 0 issues
```

Fixes #71