### PR TITLE
fix(assert): report NotContain duplicates once with all indexes

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -878,19 +878,32 @@ func NotContain(t testing.TB, actual any, expected any, opts ...Option) {
 
 	actualValue := reflect.ValueOf(actual)
 
-	foundOutput := []string{}
+	var foundIndexes []int
 	for i := range actualValue.Len() {
 		item := actualValue.Index(i).Interface()
 		if reflect.DeepEqual(item, expected) {
-			foundOutput = append(foundOutput, fmt.Sprintf("\nCollection: %s", formatSlice(actual)))
-			foundOutput = append(foundOutput, fmt.Sprintf("Found: %s at index %d", formatComparisonValue(item), i))
-			output := strings.Join(foundOutput, "\n")
-
-			cfg := processOptions(opts...)
-			errorMsg := fmt.Sprintf("\nExpected collection to NOT contain element: %s", output)
-			failWithOptions(t, cfg, errorMsg)
+			foundIndexes = append(foundIndexes, i)
 		}
 	}
+
+	if len(foundIndexes) == 0 {
+		return
+	}
+
+	var location string
+	if len(foundIndexes) == 1 {
+		location = fmt.Sprintf("Found: %s at index %d", formatComparisonValue(expected), foundIndexes[0])
+	} else {
+		idxStrs := make([]string, len(foundIndexes))
+		for i, idx := range foundIndexes {
+			idxStrs[i] = fmt.Sprintf("%d", idx)
+		}
+		location = fmt.Sprintf("Found: %s at indexes [%s]", formatComparisonValue(expected), strings.Join(idxStrs, ", "))
+	}
+
+	cfg := processOptions(opts...)
+	errorMsg := fmt.Sprintf("\nExpected collection to NOT contain element: \nCollection: %s\n%s", formatSlice(actual), location)
+	failWithOptions(t, cfg, errorMsg)
 }
 
 // NotContainDuplicates reports a test failure if the slice or array contains duplicate values.

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -890,10 +890,8 @@ func NotContain(t testing.TB, actual any, expected any, opts ...Option) {
 		return
 	}
 
-	var location string
-	if len(foundIndexes) == 1 {
-		location = fmt.Sprintf("Found: %s at index %d", formatComparisonValue(expected), foundIndexes[0])
-	} else {
+	location := fmt.Sprintf("Found: %s at index %d", formatComparisonValue(expected), foundIndexes[0])
+	if len(foundIndexes) > 1 {
 		idxStrs := make([]string, len(foundIndexes))
 		for i, idx := range foundIndexes {
 			idxStrs[i] = fmt.Sprintf("%d", idx)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -874,12 +874,13 @@ func TestNotContain_Fails_WhenItemAppearsMultipleTimes_ReportsAllIndexesOnce(t *
 
 	// The failure must be reported exactly once with all indexes listed together,
 	// instead of accumulating a growing message per matching element.
-	if c := strings.Count(message, "Expected collection to NOT contain element"); c != 1 {
-		t.Fatalf("Expected the header to appear exactly once, but it appeared %d times.\n\nFull message:\n%s", c, message)
+	if occurrences := strings.Count(message, "Expected collection to NOT contain element"); occurrences != 1 {
+		t.Fatalf("Expected the header to appear exactly once, but it appeared %d times.\n\nFull message:\n%s", occurrences, message)
 	}
 
-	if c := strings.Count(message, "Collection:"); c != 1 {
-		t.Fatalf("Expected the collection to be printed exactly once, but it appeared %d times.\n\nFull message:\n%s", c, message)
+	if occurrences := strings.Count(message, "Collection:"); occurrences != 1 {
+		t.Fatalf("Expected the collection to be printed exactly once, but it appeared %d times.\n\nFull message:\n%s",
+			occurrences, message)
 	}
 
 	if !strings.Contains(message, "at indexes [1, 3, 5]") {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -861,6 +861,48 @@ func TestNotContain_WithCustomMessage(t *testing.T) {
 	}
 }
 
+func TestNotContain_Fails_WhenItemAppearsMultipleTimes_ReportsAllIndexesOnce(t *testing.T) {
+	t.Parallel()
+
+	failed, message := assertFails(t, func(t testing.TB) {
+		NotContain(t, []string{"a", "x", "b", "x", "c", "x"}, "x")
+	})
+
+	if !failed {
+		t.Fatal("Expected test to fail, but it passed")
+	}
+
+	// The failure must be reported exactly once with all indexes listed together,
+	// instead of accumulating a growing message per matching element.
+	if c := strings.Count(message, "Expected collection to NOT contain element"); c != 1 {
+		t.Fatalf("Expected the header to appear exactly once, but it appeared %d times.\n\nFull message:\n%s", c, message)
+	}
+
+	if c := strings.Count(message, "Collection:"); c != 1 {
+		t.Fatalf("Expected the collection to be printed exactly once, but it appeared %d times.\n\nFull message:\n%s", c, message)
+	}
+
+	if !strings.Contains(message, "at indexes [1, 3, 5]") {
+		t.Fatalf("Expected message to list all matching indexes as [1, 3, 5].\n\nFull message:\n%s", message)
+	}
+}
+
+func TestNotContain_Fails_WhenItemAppearsOnce_UsesSingularIndex(t *testing.T) {
+	t.Parallel()
+
+	failed, message := assertFails(t, func(t testing.TB) {
+		NotContain(t, []int{1, 2, 3}, 2)
+	})
+
+	if !failed {
+		t.Fatal("Expected test to fail, but it passed")
+	}
+
+	if !strings.Contains(message, "at index 1") {
+		t.Fatalf("Expected message to report the single match as \"at index 1\".\n\nFull message:\n%s", message)
+	}
+}
+
 func TestContain_WithCustomMessage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> Supersedes #74, which couldn't be reopened after its branch was force-pushed. Same change, now gofmt-clean so Lint passes.

## Summary

Fixes #73.

`NotContain` was meant to fail once and point at where the unexpected element was found. When the element appeared at more than one index, it instead failed **once per match**, and because the output slice was declared *outside* the loop and appended to on every match, each successive failure message re-printed everything before it — the error grew with each occurrence.

## Root cause

In `assert/assertions.go`, `NotContain` accumulated `foundOutput` across loop iterations and called `failWithOptions` inside the loop:

```go
foundOutput := []string{}                 // declared outside the loop
for i := range actualValue.Len() {
    if reflect.DeepEqual(item, expected) {
        foundOutput = append(foundOutput, ...)  // grows across iterations
        foundOutput = append(foundOutput, ...)
        output := strings.Join(foundOutput, "\n")
        failWithOptions(t, cfg, errorMsg)        // called once per match
    }
}
```

So `should.NotContain(t, []string{"a", "x", "b", "x", "c", "x"}, "x")` produced three separate, ever-growing errors.

## Fix

Collect all matching indexes first, then fail **exactly once**:

- No matches → no failure (unchanged).
- A single match keeps the existing wording: `Found: "x" at index 1`.
- Multiple matches are reported together: `Found: "x" at indexes [1, 3, 5]`.

New output for the reproduction in the issue:

```text
Expected collection to NOT contain element: 
Collection: ["a", "x", "b", "x", "c", "x"]
Found: "x" at indexes [1, 3, 5]
```

## Tests

Added two focused regression tests in `assert/assertions_test.go`:

- `TestNotContain_Fails_WhenItemAppearsMultipleTimes_ReportsAllIndexesOnce` — asserts the header and collection each appear exactly once and that all indexes are listed as `[1, 3, 5]`.
- `TestNotContain_Fails_WhenItemAppearsOnce_UsesSingularIndex` — guards the singular `at index N` wording for the single-match case.

## Verification

```text
go test -race -cover ./...
ok  github.com/Kairum-Labs/should          coverage: 100.0% of statements
ok  github.com/Kairum-Labs/should/assert   coverage: 96.3% of statements

golangci-lint run ./assert/...   # v2.3.0, as in CI
0 issues.

gofmt -l / go vet ./...          # clean
```

The change is limited to the `NotContain` function plus its tests.

