### PR TITLE
fix(assert): reject inverted BeInRange bounds

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -545,6 +545,12 @@ func BeWithin[T Float](t testing.TB, actual T, expected T, tolerance T, opts ...
 // Only works with numeric types. All values must be of the same type.
 func BeInRange[T Ordered](t testing.TB, actual T, minValue T, maxValue T, opts ...Option) {
 	t.Helper()
+
+	if minValue > maxValue {
+		fail(t, "BeInRange: invalid range — minValue (%v) must be less than or equal to maxValue (%v)", minValue, maxValue)
+		return
+	}
+
 	if actual >= minValue && actual <= maxValue {
 		return
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -7209,6 +7209,14 @@ func TestBeInRange(t *testing.T) {
 				shouldFail:  true,
 				expectedMsg: "Expected value to be in range [0, 100], but it was above:",
 			},
+			{
+				name:        "should fail when minimum exceeds maximum",
+				value:       5,
+				minValue:    100,
+				maxValue:    0,
+				shouldFail:  true,
+				expectedMsg: "BeInRange: invalid range — minValue (100) must be less than or equal to maxValue (0)",
+			},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
## Summary

- reject `BeInRange` calls where `minValue` exceeds `maxValue`
- report the invalid bounds before evaluating the actual value
- add regression coverage for an inverted `[100, 0]` range

## Testing

- `go test -race -cover ./...`
- `go vet ./...`

Fixes #76
