### PR TITLE
chore: swap retired Go Report Card badge for Lint CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![go](https://img.shields.io/badge/go-1.22+-blue)](https://golang.com/)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Kairum-Labs/should.svg)](https://pkg.go.dev/github.com/Kairum-Labs/should)
 [![codecov](https://codecov.io/gh/Kairum-Labs/should/branch/main/graph/badge.svg)](https://codecov.io/gh/Kairum-Labs/should)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Kairum-Labs/should)](https://goreportcard.com/report/github.com/Kairum-Labs/should)
+[![Lint](https://github.com/Kairum-Labs/should/actions/workflows/golangci.yml/badge.svg)](https://github.com/Kairum-Labs/should/actions/workflows/golangci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 <div align="center">


### PR DESCRIPTION
Go Report Card has become unreliable/retired; point to the existing golangci-lint GitHub Actions workflow instead.