### PR TITLE
chore: remove unused levenshteinDistance

### DIFF
--- a/assert/utils.go
+++ b/assert/utils.go
@@ -593,42 +593,6 @@ func calculateStringSimilarity(target, candidate string) similarItem {
 	return item
 }
 
-// levenshteinDistance calculates the Levenshtein distance between two strings
-func levenshteinDistance(s1, s2 string) int {
-	len1, len2 := len(s1), len(s2)
-
-	matrix := make([][]int, len1+1)
-	for i := range matrix {
-		matrix[i] = make([]int, len2+1)
-	}
-
-	// Initialize first row and column
-	for i := 0; i <= len1; i++ {
-		matrix[i][0] = i
-	}
-	for j := 0; j <= len2; j++ {
-		matrix[0][j] = j
-	}
-
-	// Fill matrix
-	for i := 1; i <= len1; i++ {
-		for j := 1; j <= len2; j++ {
-			cost := 0
-			if s1[i-1] != s2[j-1] {
-				cost = 1
-			}
-
-			matrix[i][j] = min3(
-				matrix[i-1][j]+1,      // deletion
-				matrix[i][j-1]+1,      // insertion
-				matrix[i-1][j-1]+cost, // substitution
-			)
-		}
-	}
-
-	return matrix[len1][len2]
-}
-
 // damerauLevenshteinDistance calculates the Damerau-Levenshtein distance between two strings.
 // Unlike standard Levenshtein, it treats transposition of adjacent characters as a single operation.
 // For example, "tets" -> "test" has distance 1 (transposition) instead of 2 (delete + insert).

--- a/assert/utils_test.go
+++ b/assert/utils_test.go
@@ -1152,55 +1152,6 @@ func TestFormatValueComparison_EdgeCases(t *testing.T) {
 	})
 }
 
-func TestLevenshteinDistance(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name     string
-		s1, s2   string
-		expected int
-	}{
-		{
-			name:     "Empty strings",
-			s1:       "",
-			s2:       "",
-			expected: 0,
-		},
-		{
-			name:     "One empty string",
-			s1:       "hello",
-			s2:       "",
-			expected: 5,
-		},
-		{
-			name:     "Identical strings",
-			s1:       "hello",
-			s2:       "hello",
-			expected: 0,
-		},
-		{
-			name:     "Single character difference",
-			s1:       "hello",
-			s2:       "hallo",
-			expected: 1,
-		},
-		{
-			name:     "Multiple differences",
-			s1:       "kitten",
-			s2:       "sitting",
-			expected: 3,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			result := levenshteinDistance(tc.s1, tc.s2)
-			BeEqual(t, result, tc.expected)
-		})
-	}
-}
-
 func TestGenerateTypoDetails(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
damerauLevenshteinDistance is used everywhere in production; the plain Levenshtein variant was only exercised by its own test.