### PR TITLE
fix(assert): report BeEqual nil-literal mismatch instead of panicking

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -665,6 +665,19 @@ func BeEqual(t testing.TB, actual any, expected any, opts ...Option) {
 	actualValue := reflect.ValueOf(actual)
 	expectedValue := reflect.ValueOf(expected)
 
+	// A literal nil passed for actual/expected becomes an invalid reflect.Value
+	// (no type to describe), and reflect.Value.Type panics on those. Since
+	// reflect.DeepEqual already ruled out "both nil", one side must hold a
+	// real value here, so report the mismatch directly instead of reflecting.
+	if !actualValue.IsValid() || !expectedValue.IsValid() {
+		fail(t, "%sNot equal:\nexpected: %s\nactual  : %s",
+			customMsg,
+			formatComparisonValue(expected),
+			formatComparisonValue(actual),
+		)
+		return
+	}
+
 	actualType := actualValue.Type()
 	expectedType := expectedValue.Type()
 	typesAreDifferent := actualType != expectedType

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -264,6 +264,56 @@ func TestBeEqual_ForMaps_Fails_WhenNotEqual(t *testing.T) {
 	}
 }
 
+func TestBeEqual_ActualNonNil_ExpectedNilLiteral_FailsWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("boom")
+
+	failed, message := assertFails(t, func(t testing.TB) {
+		BeEqual(t, err, nil)
+	})
+
+	if !failed {
+		t.Fatal("Expected test to fail, but it passed")
+	}
+
+	expected := "expected: nil"
+	if !strings.Contains(message, expected) {
+		t.Fatalf("Expected message to contain %q, but got %q", expected, message)
+	}
+}
+
+func TestBeEqual_ExpectedNonNil_ActualNilLiteral_FailsWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("boom")
+
+	failed, message := assertFails(t, func(t testing.TB) {
+		BeEqual(t, nil, err)
+	})
+
+	if !failed {
+		t.Fatal("Expected test to fail, but it passed")
+	}
+
+	expected := "actual  : nil"
+	if !strings.Contains(message, expected) {
+		t.Fatalf("Expected message to contain %q, but got %q", expected, message)
+	}
+}
+
+func TestBeEqual_BothNilLiteral_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	failed, _ := assertFails(t, func(t testing.TB) {
+		BeEqual(t, nil, nil)
+	})
+
+	if failed {
+		t.Fatal("Expected test to pass, but it failed")
+	}
+}
+
 func TestBeEqual_PrimitiveFormatting(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
reflect.ValueOf(nil) returns an invalid reflect.Value, and BeEqual called .Type() on it unconditionally when building the diff message. Whenever a real failure compared a value against a literal nil (e.g. should.BeEqual(t, err, nil) with a non-nil err), the assertion crashed the whole test process with a reflect panic instead of reporting FAIL.